### PR TITLE
Add 2010 pre/post event imagery sources

### DIFF
--- a/data/imagery.json
+++ b/data/imagery.json
@@ -1,11 +1,180 @@
 {
     "dataImagery": [
         {
+            "id": "2010-eq-post-event",
+            "name": "2010 EQ post-event imagery",
+            "type": "tms",
+            "template": "http://tiles.staging.openaerialmap.org/58ef73b596b4910010327d45/0/{z}/{x}/{y}.png"
+        },
+        {
+            "id": "2010-eq-pre-event",
+            "name": "2010 EQ pre-event imagery",
+            "type": "tms",
+            "template": "http://tiles.staging.openaerialmap.org/58efcec02d30b500119a84f4/0/{z}/{x}/{y}.png"
+        },
+        {
             "id": "sjcgis.org-Aerials_2013_WM",
             "name": "2013 aerial imagery for San Juan County WA",
             "type": "tms",
             "template": "http://sjcgis.org/arcgis/rest/services/Basemaps/Aerials_2013_WM/MapServer/tile/{zoom}/{y}/{x}",
             "description": "Public domain aerial imagery taken in May/June 2013 from San Juan County, WA. Resolution is 9 inch.",
+            "scaleExtent": [
+                0,
+                19
+            ],
+            "polygon": [
+                [
+                    [
+                        -123.02167396992,
+                        48.44667085335
+                    ],
+                    [
+                        -122.9466579482,
+                        48.44780949945
+                    ],
+                    [
+                        -122.90151100606,
+                        48.41306930778
+                    ],
+                    [
+                        -122.80263405293,
+                        48.40771378918
+                    ],
+                    [
+                        -122.79199104756,
+                        48.44279926564
+                    ],
+                    [
+                        -122.8088138625,
+                        48.47865708877
+                    ],
+                    [
+                        -122.73911934346,
+                        48.49572334021
+                    ],
+                    [
+                        -122.78546791524,
+                        48.62160819278
+                    ],
+                    [
+                        -122.73087959737,
+                        48.6361306644
+                    ],
+                    [
+                        -122.75559883565,
+                        48.71207854113
+                    ],
+                    [
+                        -122.95747261494,
+                        48.71592956034
+                    ],
+                    [
+                        -122.97086220235,
+                        48.695765074
+                    ],
+                    [
+                        -122.99970131367,
+                        48.69780454658
+                    ],
+                    [
+                        -123.00347786397,
+                        48.73427448605
+                    ],
+                    [
+                        -123.04330330342,
+                        48.74310484148
+                    ],
+                    [
+                        -123.0762622878,
+                        48.70528190578
+                    ],
+                    [
+                        -123.08484535664,
+                        48.66334903433
+                    ],
+                    [
+                        -123.12844734639,
+                        48.66380254936
+                    ],
+                    [
+                        -123.22698097676,
+                        48.70301615666
+                    ],
+                    [
+                        -123.24655037373,
+                        48.68352650341
+                    ],
+                    [
+                        -123.17445259541,
+                        48.64701977542
+                    ],
+                    [
+                        -123.21513634175,
+                        48.60106537642
+                    ],
+                    [
+                        -123.21393471211,
+                        48.57335906966
+                    ],
+                    [
+                        -123.18080406636,
+                        48.56574853208
+                    ],
+                    [
+                        -123.16621284932,
+                        48.52006125122
+                    ],
+                    [
+                        -123.10235481709,
+                        48.47683634964
+                    ],
+                    [
+                        -123.02167396992,
+                        48.44667085335
+                    ]
+                ],
+                [
+                    [
+                        -122.98339348286,
+                        48.78214357977
+                    ],
+                    [
+                        -122.93498497456,
+                        48.76653172572
+                    ],
+                    [
+                        -122.91181068867,
+                        48.73857664785
+                    ],
+                    [
+                        -122.80229073018,
+                        48.73982194177
+                    ],
+                    [
+                        -122.81945686787,
+                        48.75498940888
+                    ],
+                    [
+                        -122.93429832906,
+                        48.79571515892
+                    ],
+                    [
+                        -122.98373680562,
+                        48.79435816618
+                    ],
+                    [
+                        -122.98339348286,
+                        48.78214357977
+                    ]
+                ]
+            ]
+        },
+        {
+            "id": "sjcgis.org-Aerials_2016_WM",
+            "name": "2016 aerial imagery for San Juan County WA",
+            "type": "tms",
+            "template": "http://sjcgis.org/arcgis/rest/services/Basemaps/Aerials_2016_WM/MapServer/tile/{zoom}/{y}/{x}",
+            "description": "Public domain aerial imagery taken in May, June, and July from San Juan County, WA. Resolution is 6 inch countywide.",
             "scaleExtent": [
                 0,
                 19
@@ -5465,7 +5634,7 @@
                     ]
                 ]
             ],
-            "terms_text": "GRB Flanders (c) AGIV"
+            "terms_text": "GRB Flanders © AGIV"
         },
         {
             "id": "AGIV",
@@ -5772,7 +5941,7 @@
                     ]
                 ]
             ],
-            "terms_text": "Orthophoto Flanders most recent (c) AGIV",
+            "terms_text": "Orthophoto Flanders most recent © AGIV",
             "best": true
         },
         {
@@ -13990,7 +14159,7 @@
         },
         {
             "id": "Duna_2013",
-            "name": "Danube flood ortophoto 2013",
+            "name": "Danube flood orthophoto 2013",
             "type": "tms",
             "template": "http://e.tile.openstreetmap.hu/dunai-arviz-2013/{zoom}/{x}/{y}.jpg",
             "scaleExtent": [
@@ -14110,6 +14279,34 @@
             "terms_text": "Digital Aerial Solutions, LLC"
         },
         {
+            "id": "DigitalGlobe-Premium",
+            "name": "DigitalGlobe Premium Imagery",
+            "type": "tms",
+            "template": "https://{switch:a,b,c}.tiles.mapbox.com/v4/digitalglobe.316c9a2e/{zoom}/{x}/{y}.png?access_token=pk.eyJ1IjoiZGlnaXRhbGdsb2JlIiwiYSI6ImNqM293YnJ5MTAwajIzMnF0bmV4dnV1MW4ifQ.psvzzOez33BOH8xmRiJZWg",
+            "description": "Premium DigitalGlobe satellite imagery.",
+            "scaleExtent": [
+                0,
+                19
+            ],
+            "terms_url": "https://wiki.openstreetmap.org/wiki/DigitalGlobe",
+            "terms_text": "Terms & Feedback",
+            "default": true
+        },
+        {
+            "id": "DigitalGlobe-Standard",
+            "name": "DigitalGlobe Standard Imagery",
+            "type": "tms",
+            "template": "https://{switch:a,b,c}.tiles.mapbox.com/v4/digitalglobe.0a8e44ba/{zoom}/{x}/{y}.png?access_token=pk.eyJ1IjoiZGlnaXRhbGdsb2JlIiwiYSI6ImNqM293Y3Y5ZjAwaWgycW55ZXFncHk0a3QifQ.6Kprj_J4oDmXqV97RricwA",
+            "description": "Standard DigitalGlobe satellite imagery.",
+            "scaleExtent": [
+                0,
+                19
+            ],
+            "terms_url": "https://wiki.openstreetmap.org/wiki/DigitalGlobe",
+            "terms_text": "Terms & Feedback",
+            "default": true
+        },
+        {
             "id": "maaamet.ee-orto",
             "name": "Estonia Ortho (Maaamet)",
             "type": "tms",
@@ -14142,14 +14339,13 @@
                     ]
                 ]
             ],
-            "terms_text": "Maa-Ameti ortofoto "
+            "terms_text": "Maa-Ameti ortofoto"
         },
         {
             "id": "FOMI_2000",
-            "name": "FÖMI ortofotó 2000",
+            "name": "FÖMI orthophoto 2000",
             "type": "tms",
             "template": "http://e.tile.openstreetmap.hu/ortofoto2000/{zoom}/{x}/{y}.jpg",
-            "description": "Hungary",
             "scaleExtent": [
                 0,
                 17
@@ -16455,10 +16651,9 @@
         },
         {
             "id": "FOMI_2005",
-            "name": "FÖMI ortofotó 2005",
+            "name": "FÖMI orthophoto 2005",
             "type": "tms",
             "template": "http://e.tile.openstreetmap.hu/ortofoto2005/{zoom}/{x}/{y}.jpg",
-            "description": "Hungary",
             "scaleExtent": [
                 0,
                 17
@@ -20211,651 +20406,6 @@
                 ]
             ],
             "terms_text": "Copyright ©2007-2012 Freemap Slovakia (www.freemap.sk). Some rights reserved."
-        },
-        {
-            "id": "Geodatastyrelsen_Denmark",
-            "name": "Geodatastyrelsen (Denmark)",
-            "type": "tms",
-            "template": "http://osmtools.septima.dk/mapproxy/tiles/1.0.0/kortforsyningen_ortoforaar/EPSG3857/{zoom}/{x}/{y}.jpeg",
-            "scaleExtent": [
-                0,
-                21
-            ],
-            "polygon": [
-                [
-                    [
-                        8.3743941,
-                        54.9551655
-                    ],
-                    [
-                        8.3683809,
-                        55.4042149
-                    ],
-                    [
-                        8.2103997,
-                        55.4039795
-                    ],
-                    [
-                        8.2087314,
-                        55.4937345
-                    ],
-                    [
-                        8.0502655,
-                        55.4924731
-                    ],
-                    [
-                        8.0185123,
-                        56.7501399
-                    ],
-                    [
-                        8.1819161,
-                        56.7509948
-                    ],
-                    [
-                        8.1763274,
-                        57.0208898
-                    ],
-                    [
-                        8.3413329,
-                        57.0219872
-                    ],
-                    [
-                        8.3392467,
-                        57.1119574
-                    ],
-                    [
-                        8.5054433,
-                        57.1123212
-                    ],
-                    [
-                        8.5033923,
-                        57.2020499
-                    ],
-                    [
-                        9.3316304,
-                        57.2027636
-                    ],
-                    [
-                        9.3319079,
-                        57.2924835
-                    ],
-                    [
-                        9.4978864,
-                        57.2919578
-                    ],
-                    [
-                        9.4988593,
-                        57.3820608
-                    ],
-                    [
-                        9.6649749,
-                        57.3811615
-                    ],
-                    [
-                        9.6687295,
-                        57.5605591
-                    ],
-                    [
-                        9.8351961,
-                        57.5596265
-                    ],
-                    [
-                        9.8374896,
-                        57.6493322
-                    ],
-                    [
-                        10.1725726,
-                        57.6462818
-                    ],
-                    [
-                        10.1754245,
-                        57.7367768
-                    ],
-                    [
-                        10.5118282,
-                        57.7330269
-                    ],
-                    [
-                        10.5152095,
-                        57.8228945
-                    ],
-                    [
-                        10.6834853,
-                        57.8207722
-                    ],
-                    [
-                        10.6751613,
-                        57.6412021
-                    ],
-                    [
-                        10.5077045,
-                        57.6433097
-                    ],
-                    [
-                        10.5039992,
-                        57.5535088
-                    ],
-                    [
-                        10.671038,
-                        57.5514113
-                    ],
-                    [
-                        10.6507805,
-                        57.1024538
-                    ],
-                    [
-                        10.4857673,
-                        57.1045138
-                    ],
-                    [
-                        10.4786236,
-                        56.9249051
-                    ],
-                    [
-                        10.3143981,
-                        56.9267573
-                    ],
-                    [
-                        10.3112341,
-                        56.8369269
-                    ],
-                    [
-                        10.4750295,
-                        56.83509
-                    ],
-                    [
-                        10.4649016,
-                        56.5656681
-                    ],
-                    [
-                        10.9524239,
-                        56.5589761
-                    ],
-                    [
-                        10.9479249,
-                        56.4692243
-                    ],
-                    [
-                        11.1099335,
-                        56.4664675
-                    ],
-                    [
-                        11.1052639,
-                        56.376833
-                    ],
-                    [
-                        10.9429901,
-                        56.3795284
-                    ],
-                    [
-                        10.9341235,
-                        56.1994768
-                    ],
-                    [
-                        10.7719685,
-                        56.2020244
-                    ],
-                    [
-                        10.7694751,
-                        56.1120103
-                    ],
-                    [
-                        10.6079695,
-                        56.1150259
-                    ],
-                    [
-                        10.4466742,
-                        56.116717
-                    ],
-                    [
-                        10.2865948,
-                        56.118675
-                    ],
-                    [
-                        10.2831527,
-                        56.0281851
-                    ],
-                    [
-                        10.4439274,
-                        56.0270388
-                    ],
-                    [
-                        10.4417713,
-                        55.7579243
-                    ],
-                    [
-                        10.4334961,
-                        55.6693533
-                    ],
-                    [
-                        10.743814,
-                        55.6646861
-                    ],
-                    [
-                        10.743814,
-                        55.5712253
-                    ],
-                    [
-                        10.8969041,
-                        55.5712253
-                    ],
-                    [
-                        10.9051793,
-                        55.3953852
-                    ],
-                    [
-                        11.0613726,
-                        55.3812841
-                    ],
-                    [
-                        11.0593038,
-                        55.1124061
-                    ],
-                    [
-                        11.0458567,
-                        55.0318621
-                    ],
-                    [
-                        11.2030844,
-                        55.0247474
-                    ],
-                    [
-                        11.2030844,
-                        55.117139
-                    ],
-                    [
-                        11.0593038,
-                        55.1124061
-                    ],
-                    [
-                        11.0613726,
-                        55.3812841
-                    ],
-                    [
-                        11.0789572,
-                        55.5712253
-                    ],
-                    [
-                        10.8969041,
-                        55.5712253
-                    ],
-                    [
-                        10.9258671,
-                        55.6670198
-                    ],
-                    [
-                        10.743814,
-                        55.6646861
-                    ],
-                    [
-                        10.7562267,
-                        55.7579243
-                    ],
-                    [
-                        10.4417713,
-                        55.7579243
-                    ],
-                    [
-                        10.4439274,
-                        56.0270388
-                    ],
-                    [
-                        10.4466742,
-                        56.116717
-                    ],
-                    [
-                        10.6079695,
-                        56.1150259
-                    ],
-                    [
-                        10.6052053,
-                        56.0247462
-                    ],
-                    [
-                        10.9258671,
-                        56.0201215
-                    ],
-                    [
-                        10.9197132,
-                        55.9309388
-                    ],
-                    [
-                        11.0802782,
-                        55.92792
-                    ],
-                    [
-                        11.0858066,
-                        56.0178284
-                    ],
-                    [
-                        11.7265047,
-                        56.005058
-                    ],
-                    [
-                        11.7319981,
-                        56.0952142
-                    ],
-                    [
-                        12.0540333,
-                        56.0871256
-                    ],
-                    [
-                        12.0608477,
-                        56.1762576
-                    ],
-                    [
-                        12.7023469,
-                        56.1594405
-                    ],
-                    [
-                        12.6611131,
-                        55.7114318
-                    ],
-                    [
-                        12.9792318,
-                        55.7014026
-                    ],
-                    [
-                        12.9612912,
-                        55.5217294
-                    ],
-                    [
-                        12.3268659,
-                        55.5412096
-                    ],
-                    [
-                        12.3206071,
-                        55.4513655
-                    ],
-                    [
-                        12.4778226,
-                        55.447067
-                    ],
-                    [
-                        12.4702432,
-                        55.3570479
-                    ],
-                    [
-                        12.6269738,
-                        55.3523837
-                    ],
-                    [
-                        12.6200898,
-                        55.2632576
-                    ],
-                    [
-                        12.4627339,
-                        55.26722
-                    ],
-                    [
-                        12.4552949,
-                        55.1778223
-                    ],
-                    [
-                        12.2987046,
-                        55.1822303
-                    ],
-                    [
-                        12.2897344,
-                        55.0923641
-                    ],
-                    [
-                        12.6048608,
-                        55.0832904
-                    ],
-                    [
-                        12.5872011,
-                        54.9036285
-                    ],
-                    [
-                        12.2766618,
-                        54.9119031
-                    ],
-                    [
-                        12.2610181,
-                        54.7331602
-                    ],
-                    [
-                        12.1070691,
-                        54.7378161
-                    ],
-                    [
-                        12.0858621,
-                        54.4681655
-                    ],
-                    [
-                        11.7794953,
-                        54.4753579
-                    ],
-                    [
-                        11.7837381,
-                        54.5654783
-                    ],
-                    [
-                        11.1658525,
-                        54.5782155
-                    ],
-                    [
-                        11.1706443,
-                        54.6686508
-                    ],
-                    [
-                        10.8617173,
-                        54.6733956
-                    ],
-                    [
-                        10.8651245,
-                        54.7634667
-                    ],
-                    [
-                        10.7713646,
-                        54.7643888
-                    ],
-                    [
-                        10.7707276,
-                        54.7372807
-                    ],
-                    [
-                        10.7551428,
-                        54.7375776
-                    ],
-                    [
-                        10.7544039,
-                        54.7195666
-                    ],
-                    [
-                        10.7389074,
-                        54.7197588
-                    ],
-                    [
-                        10.7384368,
-                        54.7108482
-                    ],
-                    [
-                        10.7074486,
-                        54.7113045
-                    ],
-                    [
-                        10.7041094,
-                        54.6756741
-                    ],
-                    [
-                        10.5510973,
-                        54.6781698
-                    ],
-                    [
-                        10.5547184,
-                        54.7670245
-                    ],
-                    [
-                        10.2423994,
-                        54.7705935
-                    ],
-                    [
-                        10.2459845,
-                        54.8604673
-                    ],
-                    [
-                        10.0902268,
-                        54.8622134
-                    ],
-                    [
-                        10.0873731,
-                        54.7723851
-                    ],
-                    [
-                        9.1555798,
-                        54.7769557
-                    ],
-                    [
-                        9.1562752,
-                        54.8675369
-                    ],
-                    [
-                        8.5321973,
-                        54.8663765
-                    ],
-                    [
-                        8.531432,
-                        54.95516
-                    ],
-                    [
-                        8.3743941,
-                        54.9551655
-                    ]
-                ],
-                [
-                    [
-                        11.4577738,
-                        56.819554
-                    ],
-                    [
-                        11.7849181,
-                        56.8127385
-                    ],
-                    [
-                        11.7716715,
-                        56.6332796
-                    ],
-                    [
-                        11.4459621,
-                        56.6401087
-                    ],
-                    [
-                        11.4577738,
-                        56.819554
-                    ]
-                ],
-                [
-                    [
-                        11.3274736,
-                        57.3612962
-                    ],
-                    [
-                        11.3161808,
-                        57.1818004
-                    ],
-                    [
-                        11.1508692,
-                        57.1847276
-                    ],
-                    [
-                        11.1456628,
-                        57.094962
-                    ],
-                    [
-                        10.8157703,
-                        57.1001693
-                    ],
-                    [
-                        10.8290599,
-                        57.3695272
-                    ],
-                    [
-                        11.3274736,
-                        57.3612962
-                    ]
-                ],
-                [
-                    [
-                        11.5843266,
-                        56.2777928
-                    ],
-                    [
-                        11.5782882,
-                        56.1880397
-                    ],
-                    [
-                        11.7392309,
-                        56.1845765
-                    ],
-                    [
-                        11.7456428,
-                        56.2743186
-                    ],
-                    [
-                        11.5843266,
-                        56.2777928
-                    ]
-                ],
-                [
-                    [
-                        14.6825922,
-                        55.3639405
-                    ],
-                    [
-                        14.8395247,
-                        55.3565231
-                    ],
-                    [
-                        14.8263755,
-                        55.2671261
-                    ],
-                    [
-                        15.1393406,
-                        55.2517359
-                    ],
-                    [
-                        15.1532015,
-                        55.3410836
-                    ],
-                    [
-                        15.309925,
-                        55.3330556
-                    ],
-                    [
-                        15.295719,
-                        55.2437356
-                    ],
-                    [
-                        15.1393406,
-                        55.2517359
-                    ],
-                    [
-                        15.1255631,
-                        55.1623802
-                    ],
-                    [
-                        15.2815819,
-                        55.1544167
-                    ],
-                    [
-                        15.2535578,
-                        54.9757646
-                    ],
-                    [
-                        14.6317464,
-                        55.0062496
-                    ],
-                    [
-                        14.6825922,
-                        55.3639405
-                    ]
-                ]
-            ],
-            "terms_url": "http://download.kortforsyningen.dk/content/vilkaar-og-betingelser",
-            "terms_text": "Geodatastyrelsen og Danske Kommuner",
-            "best": true
         },
         {
             "id": "Geoportal-PL-aerial_image",
@@ -25006,7 +24556,7 @@
             "name": "imagico.de OSM images for mapping: Adams Bridge",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R119_N09_20160327T050917&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_OPER_PRD_MSIL1C_PDMC_20160330T091608_R119_V20160327T050917_20160327T050917, 2016-03-27, channels 234 (true color), Supplementing incomplete coverage in other sources",
+            "description": "Supplementing incomplete coverage in other sources (true color)",
             "scaleExtent": [
                 0,
                 14
@@ -25043,7 +24593,7 @@
             "name": "imagico.de OSM images for mapping: Alaska Range",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC80700162014211LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC80700162014211LGN00, 2014-07-31 channels 234 (true color), Recent summer image of the Alaska Range for mapping natural features",
+            "description": "Recent summer image of the Alaska Range for mapping natural features (true color)",
             "scaleExtent": [
                 0,
                 12
@@ -25084,7 +24634,7 @@
             "name": "imagico.de OSM images for mapping: Bakun Reservoir",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC81190582014075LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC81190582014075LGN00/LC81180582015183LGN00, 2014-03-16, channels 234 (true color), Missing in older pre-2011 images",
+            "description": "Missing in older pre-2011 images (true color)",
             "scaleExtent": [
                 0,
                 13
@@ -25125,7 +24675,7 @@
             "name": "imagico.de OSM images for mapping: Batam",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC81250592016107LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC81250592016107LGN00, LC81250602015184LGN00, LC81240602014174LGN00, 2014 to 2016, channels 234 (true color), Missing Islands in OSM",
+            "description": "Missing Islands in OSM (true color)",
             "scaleExtent": [
                 0,
                 13
@@ -25162,7 +24712,7 @@
             "name": "imagico.de OSM images for mapping: Bouvet Island",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC81800982013291LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC81800982013291LGN00, 2013-10-18, channels 234 (true color), For more accurate coastline and glacier mapping",
+            "description": "For more accurate coastline and glacier mapping (true color)",
             "scaleExtent": [
                 0,
                 13
@@ -25200,7 +24750,7 @@
             "name": "imagico.de OSM images for mapping: Cental Alps in late September 2016",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R065_N47_20160929T102022&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_OPER_PRD_MSIL1C_PDMC_20160929Txxxxxx_R065_V20160929T102022_20160929T102344, 2016-09-29, channels 234 (true color), Up-to-date image for glacier mapping - beware of some fresh snow at higher altitudes",
+            "description": "Up-to-date image for glacier mapping - beware of some fresh snow at higher altitudes (true color)",
             "scaleExtent": [
                 0,
                 13
@@ -25249,7 +24799,7 @@
             "name": "imagico.de OSM images for mapping: Clerke Rocks",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC82050982015344LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC82050982015344LGN00, 2015-12-10, channels 234 (true color), Missing in other image sources",
+            "description": "Missing in other image sources (true color)",
             "scaleExtent": [
                 0,
                 13
@@ -25290,7 +24840,7 @@
             "name": "imagico.de OSM images for mapping: Coropuna",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=EO1A0040712016264110KF&z={zoom}&x={x}&y={-y}",
-            "description": "EO1A0040712016264110KF, 2016-09-21, channels 123 (true color), Up-to-date image for glacier mapping",
+            "description": "Up-to-date image for glacier mapping (true color)",
             "scaleExtent": [
                 0,
                 14
@@ -25335,7 +24885,7 @@
             "name": "imagico.de OSM images for mapping: Cotonou",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R022_N06_20151221T103009&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_OPER_PRD_MSIL1C_PDMC_20151222T164644_R022_V20151221T103009_20151221T103009, 2015-12-21, channels 234 (true color), Patchy and partly cloudy coverage in usual sources",
+            "description": "Patchy and partly cloudy coverage in usual sources (true color)",
             "scaleExtent": [
                 0,
                 14
@@ -25376,7 +24926,7 @@
             "name": "imagico.de OSM images for mapping: Darwin and Wolf islands, Galapagos",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R040_N01_20160311T164128&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_OPER_PRD_MSIL1C_PDMC_20160312T000419_R040_V20160311T164128_20160311T164128, 2016-03-11, channels 234 (true color), Recent image, only old and poor images in other sources currently",
+            "description": "Recent image, only old and poor images in other sources currently (true color)",
             "scaleExtent": [
                 0,
                 14
@@ -25413,7 +24963,7 @@
             "name": "imagico.de OSM images for mapping: Eastern Devon Island coast",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC80360072014245LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC80360072014245LGN00/LC80380062014243LGN00, 2014-09-02, channel 654 (false color IR), Coastline mostly mapped meanwhile",
+            "description": "Coastline mostly mapped meanwhile (false color IR)",
             "scaleExtent": [
                 0,
                 11
@@ -25450,7 +25000,7 @@
             "name": "imagico.de OSM images for mapping: Eastern Iceland",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC82160152013239LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC82160152013239LGN00, 2013-08-27, channels 234 (true color), Missing islets and inaccurate coast",
+            "description": "Missing islets and inaccurate coast (true color)",
             "scaleExtent": [
                 0,
                 12
@@ -25487,7 +25037,7 @@
             "name": "imagico.de OSM images for mapping: El Altar",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=AST_L1T_00302052007154424_20150518041444_91492&z={zoom}&x={x}&y={-y}",
-            "description": "AST_L1T_00302052007154424_20150518041444_91492, 2012-02-05, channels 12x (true color with estimated blue), 2007 ASTER image offering better glacier coverage than common sources",
+            "description": "2007 ASTER image offering better glacier coverage than common sources (true color with estimated blue)",
             "scaleExtent": [
                 0,
                 14
@@ -25524,7 +25074,7 @@
             "name": "imagico.de OSM images for mapping: Elephant Island/Clarence Island",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R009_S61_20160109&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_OPER_PRD_MSIL1C_PDMC_20160109T225906_R009_V20160109T130043_20160109T130043, 2016-01-09, channels 234 (true color), Fairly clear up-to-date image for updating glacier edges",
+            "description": "Fairly clear up-to-date image for updating glacier edges (true color)",
             "scaleExtent": [
                 0,
                 13
@@ -25561,11 +25111,60 @@
             "terms_text": "imagico.de OSM images for mapping"
         },
         {
+            "id": "osmim-imagicode-enderby",
+            "name": "imagico.de OSM images for mapping: Enderby Land and Kemp Coast",
+            "type": "tms",
+            "template": "http://imagico.de/map/osmim_tiles.php?layer=enderby&z={zoom}&x={x}&y={-y}",
+            "description": "Sentinel-2 images of Enderby Land and Kemp Coast (true color)",
+            "scaleExtent": [
+                0,
+                13
+            ],
+            "polygon": [
+                [
+                    [
+                        45.4547,
+                        -68.5091
+                    ],
+                    [
+                        45.4547,
+                        -67.5724
+                    ],
+                    [
+                        49.7155,
+                        -65.7176
+                    ],
+                    [
+                        59.2693,
+                        -65.7176
+                    ],
+                    [
+                        67.3735,
+                        -67.3449
+                    ],
+                    [
+                        67.3735,
+                        -68.2581
+                    ],
+                    [
+                        67.088,
+                        -68.5091
+                    ],
+                    [
+                        45.4547,
+                        -68.5091
+                    ]
+                ]
+            ],
+            "terms_url": "http://maps.imagico.de/#osmim",
+            "terms_text": "imagico.de OSM images for mapping"
+        },
+        {
             "id": "osmim-imagicode-LC82100502015347LGN00",
             "name": "imagico.de OSM images for mapping: Fogo, Cape Verde",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC82100502015347LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC82100502015347LGN00, 2015-12-13, channels 234 (true color), Image from after the 2014/2015 eruption",
+            "description": "Image from after the 2014/2015 eruption (true color)",
             "scaleExtent": [
                 0,
                 14
@@ -25602,7 +25201,7 @@
             "name": "imagico.de OSM images for mapping: Greenland mosaic",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=greenland&z={zoom}&x={x}&y={-y}",
-            "description": "mostly Landsat 8 2013 to 2015 channels 234 (true color), Landsat mosaic of Greenland",
+            "description": "Landsat mosaic of Greenland (true color)",
             "scaleExtent": [
                 0,
                 12
@@ -25610,576 +25209,636 @@
             "polygon": [
                 [
                     [
-                        -43.335169388775576,
-                        59.78884556778711
+                        -43.9774,
+                        59.7171
                     ],
                     [
-                        -43.5940638938192,
-                        59.723921705576714
+                        -44.545,
+                        59.7302
                     ],
                     [
-                        -43.840898275878764,
-                        59.67490148496335
+                        -44.9203,
+                        59.7672
                     ],
                     [
-                        -44.23515133460447,
-                        59.653417915878954
+                        -45.3587,
+                        59.8218
                     ],
                     [
-                        -44.657213255061194,
-                        59.680989005977885
+                        -45.763,
+                        59.8848
                     ],
                     [
-                        -45.81015180316172,
-                        59.81951972989828
+                        -46.0859,
+                        59.9827
                     ],
                     [
-                        -46.81057076187592,
-                        59.98139710469466
+                        -46.3381,
+                        60.119
                     ],
                     [
-                        -47.20837894817284,
-                        60.150960472742064
+                        -46.577,
+                        60.2652
                     ],
                     [
-                        -47.22064190066637,
-                        60.33805731472787
+                        -46.8114,
+                        60.4418
                     ],
                     [
-                        -47.255916208498,
-                        60.42332684576548
+                        -47.2635,
+                        60.5314
                     ],
                     [
-                        -47.34990349056956,
-                        60.446387835215525
+                        -47.6937,
+                        60.5549
                     ],
                     [
-                        -47.51603887007207,
-                        60.45119769375011
+                        -48.1457,
+                        60.6192
                     ],
                     [
-                        -47.65139646003081,
-                        60.48896403744677
+                        -48.5771,
+                        60.7015
                     ],
                     [
-                        -47.79170835578903,
-                        60.52050863908786
+                        -48.8689,
+                        60.8506
                     ],
                     [
-                        -49.10695022655055,
-                        60.73414367492607
+                        -49.0578,
+                        61.0555
                     ],
                     [
-                        -49.52399924941209,
-                        60.97440124547532
+                        -49.396,
+                        61.2957
                     ],
                     [
-                        -50.493558334841985,
-                        61.089523147855694
+                        -49.7601,
+                        61.4934
                     ],
                     [
-                        -51.1011476720755,
-                        61.3931538528416
+                        -50.2064,
+                        61.7324
                     ],
                     [
-                        -51.226493283028084,
-                        61.8368218735183
+                        -50.4699,
+                        61.9539
                     ],
                     [
-                        -51.66491000695862,
-                        62.06066494936552
+                        -50.8647,
+                        62.1596
                     ],
                     [
-                        -51.98744899262875,
-                        62.355028063412306
+                        -51.0631,
+                        62.3869
                     ],
                     [
-                        -52.04791761614332,
-                        62.676138274608135
+                        -51.2121,
+                        62.6001
                     ],
                     [
-                        -52.68385390751712,
-                        62.89777335327022
+                        -51.3005,
+                        62.8389
                     ],
                     [
-                        -53.00141158114564,
-                        63.22960936121321
+                        -51.4238,
+                        62.9979
                     ],
                     [
-                        -52.98804591383922,
-                        63.665519960839994
+                        -51.6767,
+                        63.1944
                     ],
                     [
-                        -53.37455124039754,
-                        63.88257990608798
+                        -51.9465,
+                        63.4079
                     ],
                     [
-                        -53.462018437442744,
-                        64.21700667649995
+                        -52.0253,
+                        63.6377
                     ],
                     [
-                        -53.625006563694996,
-                        64.39608940752123
+                        -52.2255,
+                        63.8378
                     ],
                     [
-                        -53.62418230433685,
-                        64.87666336480167
+                        -52.3658,
+                        64.0705
                     ],
                     [
-                        -53.92737410039694,
-                        65.14174166474336
+                        -52.4829,
+                        64.3792
                     ],
                     [
-                        -54.58568916434171,
-                        65.51879633173807
+                        -52.4988,
+                        64.6788
                     ],
                     [
-                        -55.020580045260964,
-                        66.04786962007503
+                        -52.789,
+                        64.9063
                     ],
                     [
-                        -54.974959716968506,
-                        66.43747058777413
+                        -53.2046,
+                        65.1321
                     ],
                     [
-                        -55.04621700056885,
-                        66.81068389526814
+                        -53.6649,
+                        65.4753
                     ],
                     [
-                        -55.18883177742317,
-                        67.07445292724583
+                        -53.9977,
+                        65.8019
                     ],
                     [
-                        -55.295917291513724,
-                        67.2980754937805
+                        -54.1348,
+                        66.1568
                     ],
                     [
-                        -55.49386806070968,
-                        67.62765205772878
+                        -54.1441,
+                        66.5235
                     ],
                     [
-                        -55.58982586875712,
-                        67.74762927352513
+                        -54.2285,
+                        66.8319
                     ],
                     [
-                        -55.800191618857184,
-                        68.05623485476666
+                        -54.4519,
+                        67.303
                     ],
                     [
-                        -56.166042896634444,
-                        68.44155152338232
+                        -54.5141,
+                        67.7648
                     ],
                     [
-                        -56.086954623441976,
-                        68.68479069915158
+                        -54.604,
+                        68.2021
                     ],
                     [
-                        -55.692397350070934,
-                        69.09499941753234
+                        -54.568,
+                        68.5698
                     ],
                     [
-                        -55.78268862269791,
-                        69.35591450732602
+                        -54.598,
+                        68.8347
                     ],
                     [
-                        -55.97508469715559,
-                        69.51460160299163
+                        -54.7606,
+                        69.1207
                     ],
                     [
-                        -56.22131441053026,
-                        69.61961934478276
+                        -55.0028,
+                        69.4125
                     ],
                     [
-                        -56.28674985487528,
-                        69.75311038137812
+                        -55.2735,
+                        69.6187
                     ],
                     [
-                        -56.27734150260429,
-                        69.86115681621736
+                        -55.3808,
+                        69.8283
                     ],
                     [
-                        -56.47867255356253,
-                        69.98628865160101
+                        -55.3945,
+                        70.0838
                     ],
                     [
-                        -56.729667549723445,
-                        70.20797294037203
+                        -55.3094,
+                        70.2573
                     ],
                     [
-                        -56.780049018329095,
-                        70.4030123058809
+                        -55.4307,
+                        70.479
                     ],
                     [
-                        -56.66995480486827,
-                        70.53429026926025
+                        -55.5501,
+                        70.6707
                     ],
                     [
-                        -56.76965573535976,
-                        70.59936425752305
+                        -55.7654,
+                        70.861
                     ],
                     [
-                        -56.750047814068225,
-                        70.67605894741244
+                        -56.2489,
+                        71.2343
                     ],
                     [
-                        -56.630475021762926,
-                        70.75228057874938
+                        -56.5018,
+                        71.5429
                     ],
                     [
-                        -56.63957096755714,
-                        70.79345598378389
+                        -56.5867,
+                        71.9015
                     ],
                     [
-                        -56.95453022049966,
-                        70.92185386457368
+                        -56.5189,
+                        72.2355
                     ],
                     [
-                        -57.682941688207656,
-                        71.10356260725686
+                        -56.5085,
+                        72.5258
                     ],
                     [
-                        -57.9990573064922,
-                        71.18275256548473
+                        -56.8923,
+                        72.8144
                     ],
                     [
-                        -58.06673093129251,
-                        71.31878823942327
+                        -57.4027,
+                        73.1054
                     ],
                     [
-                        -57.73776694812512,
-                        71.73468567987527
+                        -57.8066,
+                        73.4566
                     ],
                     [
-                        -57.688607830732714,
-                        71.96425305773354
+                        -58.1461,
+                        73.7696
                     ],
                     [
-                        -57.29627634430133,
-                        72.25939767922573
+                        -58.3554,
+                        74.0972
                     ],
                     [
-                        -57.027097307050845,
-                        72.49722993388094
+                        -58.5125,
+                        74.3783
                     ],
                     [
-                        -57.22262816078322,
-                        72.61296218481311
+                        -58.7336,
+                        74.6328
                     ],
                     [
-                        -57.61910829550675,
-                        72.72652221937263
+                        -59.3551,
+                        74.8869
                     ],
                     [
-                        -58.05813139640902,
-                        73.01331566875426
+                        -60.1412,
+                        75.102
                     ],
                     [
-                        -58.76645057271363,
-                        73.2808359719379
+                        -61.0067,
+                        75.2763
                     ],
                     [
-                        -59.14761885260487,
-                        73.53482225342569
+                        -61.911,
+                        75.3886
                     ],
                     [
-                        -59.03651118375505,
-                        73.80651043385626
+                        -62.4706,
+                        75.5595
                     ],
                     [
-                        -58.8823279108656,
-                        74.19210040380365
+                        -62.9776,
+                        75.7454
                     ],
                     [
-                        -59.24788269229215,
-                        74.4273495816669
+                        -64.1463,
+                        75.779
                     ],
                     [
-                        -59.99510425025614,
-                        74.65678100854564
+                        -65.4481,
+                        75.7235
                     ],
                     [
-                        -60.806460490534164,
-                        74.7868931828055
+                        -66.7068,
+                        75.6792
                     ],
                     [
-                        -61.54936387752781,
-                        74.99717139513008
+                        -67.8379,
+                        75.6525
                     ],
                     [
-                        -62.44046860998914,
-                        75.00073689358435
+                        -69.0456,
+                        75.6195
                     ],
                     [
-                        -62.985115364477565,
-                        75.11722591645595
+                        -70.055,
+                        75.5344
                     ],
                     [
-                        -63.51928606785155,
-                        75.31691397958907
+                        -71.0898,
+                        75.4705
                     ],
                     [
-                        -63.64288486720879,
-                        75.52488932122031
+                        -72.1119,
+                        75.4476
                     ],
                     [
-                        -64.1242392273263,
-                        75.5921799154749
+                        -74.2311,
+                        76.4102
                     ],
                     [
-                        -64.58761243996756,
-                        75.53593567213079
+                        -74.5601,
+                        76.5328
                     ],
                     [
-                        -65.31057987327657,
-                        75.42103306523184
+                        -74.5601,
+                        82.6959
                     ],
                     [
-                        -65.99461388511591,
-                        75.4041967649632
+                        -14.4462,
+                        82.6959
                     ],
                     [
-                        -66.28964875049822,
-                        75.41792163747078
+                        -14.3994,
+                        82.5997
                     ],
                     [
-                        -68.76453492310549,
-                        75.13410011250316
+                        -13.5339,
+                        82.4379
                     ],
                     [
-                        -71.04622564987365,
-                        74.79937286637706
+                        -12.0312,
+                        82.3426
                     ],
                     [
-                        -73.5067977908339,
-                        75.97399646374085
+                        -10.7796,
+                        82.3196
                     ],
                     [
-                        -74.5600891113281,
-                        76.43270387722659
+                        -10.7796,
+                        80.1902
                     ],
                     [
-                        -74.5600891113281,
-                        82.6959093208192
+                        -11.2123,
+                        80.069
                     ],
                     [
-                        -12.86159673508746,
-                        82.6959093208192
+                        -11.136,
+                        79.8103
                     ],
                     [
-                        -11.878165975221727,
-                        82.54102593940235
+                        -10.7796,
+                        79.5176
                     ],
                     [
-                        -10.7796478271484,
-                        82.51186682511671
+                        -10.7796,
+                        79.0441
                     ],
                     [
-                        -10.7796478271484,
-                        78.34463154312763
+                        -11.2626,
+                        78.7128
                     ],
                     [
-                        -10.838211677734567,
-                        78.32665786610472
+                        -12.2579,
+                        78.3558
                     ],
                     [
-                        -12.549216515959552,
-                        77.9578508228317
+                        -13.2398,
+                        78.1272
                     ],
                     [
-                        -12.803493182847879,
-                        77.85845362808246
+                        -13.7649,
+                        77.9279
                     ],
                     [
-                        -12.916087338718654,
-                        77.65848905807152
+                        -14.1169,
+                        77.6779
                     ],
                     [
-                        -13.070950321133406,
-                        77.52877948776312
+                        -14.7129,
+                        77.5278
                     ],
                     [
-                        -13.47955419255021,
-                        77.40221679143431
+                        -15.5507,
+                        77.3655
                     ],
                     [
-                        -14.13060832134256,
-                        77.30552053875587
+                        -16.0936,
+                        77.0771
                     ],
                     [
-                        -14.69541342101231,
-                        77.14674387861214
+                        -16.0586,
+                        76.5548
                     ],
                     [
-                        -14.882617750618206,
-                        76.84736003108713
+                        -15.838,
+                        75.9611
                     ],
                     [
-                        -14.323648701941867,
-                        76.53205658256601
+                        -15.6879,
+                        75.4726
                     ],
                     [
-                        -12.810144796765599,
-                        76.24823964501138
+                        -16.253,
+                        75.058
                     ],
                     [
-                        -12.151831546734856,
-                        75.86267532270129
+                        -17.0427,
+                        74.6425
                     ],
                     [
-                        -12.987745033472448,
-                        75.38717284756257
+                        -18.3155,
+                        74.2702
                     ],
                     [
-                        -14.066766809859267,
-                        74.8451997920592
+                        -19.4463,
+                        73.9378
                     ],
                     [
-                        -15.423357647282502,
-                        74.4551642069618
+                        -19.8329,
+                        73.632
                     ],
                     [
-                        -17.28174157007599,
-                        74.24584688808936
+                        -20.2938,
+                        73.3524
                     ],
                     [
-                        -19.113380020736102,
-                        73.72978765991853
+                        -20.7831,
+                        73.0446
                     ],
                     [
-                        -20.062373344103577,
-                        73.11108267968514
+                        -21.01,
+                        72.6766
                     ],
                     [
-                        -20.162312506727517,
-                        72.6186060300425
+                        -20.8774,
+                        72.2926
                     ],
                     [
-                        -19.85354831628143,
-                        72.0718529721276
+                        -20.7672,
+                        71.8726
                     ],
                     [
-                        -19.943252248300748,
-                        71.55019790921727
+                        -20.7765,
+                        71.4304
                     ],
                     [
-                        -20.918542646451737,
-                        70.67423312425346
+                        -20.9411,
+                        70.9802
                     ],
                     [
-                        -21.379621573201593,
-                        70.27938590726379
+                        -21.219,
+                        70.6126
                     ],
                     [
-                        -21.725469254364587,
-                        70.05299977015657
+                        -21.5326,
+                        70.3001
                     ],
                     [
-                        -21.93869730345768,
-                        69.92215619574657
+                        -21.8039,
+                        70.0911
                     ],
                     [
-                        -22.463306498894173,
-                        69.6235894257334
+                        -22.166,
+                        69.8947
                     ],
                     [
-                        -23.059252433112615,
-                        69.5491649852365
+                        -22.4831,
+                        69.7539
                     ],
                     [
-                        -23.860796144964162,
-                        69.34443527043162
+                        -22.9027,
+                        69.6585
                     ],
                     [
-                        -24.74741743781591,
-                        68.93340370554307
+                        -23.3545,
+                        69.544
                     ],
                     [
-                        -25.481987646795183,
-                        68.76711754662492
+                        -23.9177,
+                        69.4036
                     ],
                     [
-                        -25.815395630476477,
-                        68.51279831615729
+                        -24.1794,
+                        69.3088
                     ],
                     [
-                        -26.344103298317982,
-                        68.32443780018751
+                        -24.6745,
+                        69.1084
                     ],
                     [
-                        -27.449680541202035,
-                        68.19315579455328
+                        -25.1222,
+                        68.9555
                     ],
                     [
-                        -28.42826258633533,
-                        67.66140945836786
+                        -25.6659,
+                        68.7995
                     ],
                     [
-                        -29.237141834543507,
-                        67.60310787132272
+                        -26.0994,
+                        68.583
                     ],
                     [
-                        -30.062476147434136,
-                        67.41414423917192
+                        -26.6316,
+                        68.4043
                     ],
                     [
-                        -31.96817868027385,
-                        66.21262359095492
+                        -27.7638,
+                        68.2813
                     ],
                     [
-                        -33.33718066100074,
-                        65.93894291103432
+                        -28.4575,
+                        68.0023
                     ],
                     [
-                        -33.86781919039464,
-                        65.7415652217968
+                        -29.353,
+                        67.8135
                     ],
                     [
-                        -34.94415141573626,
-                        65.29121928843726
+                        -30.6456,
+                        67.4911
                     ],
                     [
-                        -36.438872573697054,
-                        65.22802281646563
+                        -31.7673,
+                        67.0005
                     ],
                     [
-                        -36.716767002697864,
-                        65.14683055370199
+                        -32.9783,
+                        66.2596
                     ],
                     [
-                        -36.97927615837815,
-                        64.90967633661491
+                        -33.9313,
+                        66.0156
                     ],
                     [
-                        -37.473922616631825,
-                        64.38546237809376
+                        -34.8956,
+                        65.7403
                     ],
                     [
-                        -38.95785728548117,
-                        62.7419538908273
+                        -35.5914,
+                        65.5208
                     ],
                     [
-                        -39.61555442323402,
-                        61.96904156671025
+                        -36.1483,
+                        65.372
                     ],
                     [
-                        -40.549088272349444,
-                        60.92614046823071
+                        -36.7532,
+                        65.2559
                     ],
                     [
-                        -41.17137829347243,
-                        60.43812852329213
+                        -37.1858,
+                        65.1349
                     ],
                     [
-                        -42.07544989793619,
-                        60.311876129737485
+                        -37.6032,
+                        64.9727
                     ],
                     [
-                        -42.734129957211564,
-                        60.001556976048406
+                        -38.0624,
+                        64.4901
                     ],
                     [
-                        -43.335169388775576,
-                        59.78884556778711
+                        -38.5304,
+                        64.1244
+                    ],
+                    [
+                        -39.0545,
+                        63.7213
+                    ],
+                    [
+                        -39.3131,
+                        63.4405
+                    ],
+                    [
+                        -39.5739,
+                        62.7506
+                    ],
+                    [
+                        -39.9532,
+                        62.2739
+                    ],
+                    [
+                        -40.2757,
+                        61.8547
+                    ],
+                    [
+                        -40.714,
+                        61.3365
+                    ],
+                    [
+                        -41.2091,
+                        60.8495
+                    ],
+                    [
+                        -41.821,
+                        60.5526
+                    ],
+                    [
+                        -42.4368,
+                        60.3264
+                    ],
+                    [
+                        -42.8643,
+                        60.0299
+                    ],
+                    [
+                        -43.1131,
+                        59.9147
+                    ],
+                    [
+                        -43.3282,
+                        59.83
+                    ],
+                    [
+                        -43.5459,
+                        59.7695
+                    ],
+                    [
+                        -43.797,
+                        59.7284
+                    ],
+                    [
+                        -43.9774,
+                        59.7171
                     ]
                 ]
             ],
@@ -26191,7 +25850,7 @@
             "name": "imagico.de OSM images for mapping: Heard Island coast",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R047_S54_20160411T044330&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_OPER_PRD_MSIL1C_PDMC_20160412T212111_R047_V20160411T044330_20160411T044330, 2016-04-12, channels 234 (true color), Recent image of Heard island with interior mostly cloud covered but mostly well visible coast",
+            "description": "Recent image of Heard island with interior mostly cloud covered but mostly well visible coast (true color)",
             "scaleExtent": [
                 0,
                 13
@@ -26232,7 +25891,7 @@
             "name": "imagico.de OSM images for mapping: Isla Londonderry",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC82280982013259LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC82280982013259LGN00, 2013-09-16, channel 654 (false color IR), A lot of very coarse coastlines could be improved here, much snow cover though so no use for glacier mapping",
+            "description": "A lot of very coarse coastlines could be improved here, much snow cover though so no use for glacier mapping (false color IR)",
             "scaleExtent": [
                 0,
                 12
@@ -26281,7 +25940,7 @@
             "name": "imagico.de OSM images for mapping: Kerch Strait",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R021_N44_20160807T083013&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_OPER_PRD_MSIL1C_PDMC_20160807T224006_R021_V20160807T083013_20160807T083013, 2016-08-07, channels 234 (true color), State of bridge construction in August 2016",
+            "description": "State of bridge construction in August 2016 (true color)",
             "scaleExtent": [
                 0,
                 14
@@ -26318,7 +25977,7 @@
             "name": "imagico.de OSM images for mapping: Landsat off-nadir July 2016",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=ls_polar2&z={zoom}&x={x}&y={-y}",
-            "description": "LC80402432016199LGN00-LC80402482016199LGN00, 2016-07-17, channels 234 (true color), Latest images north of the regular Landsat limit",
+            "description": "Latest images north of the regular Landsat limit (true color)",
             "scaleExtent": [
                 0,
                 10
@@ -26367,7 +26026,7 @@
             "name": "imagico.de OSM images for mapping: Leskov Island ASTER",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=AST_L1T_00311162013112731_20150618142416_109190&z={zoom}&x={x}&y={-y}",
-            "description": "AST_L1T_00311162013112731_20150618142416_109190, 2013-11-16, channels 12x (true color with estimated blue), Missing in other image sources",
+            "description": "Missing in other image sources (true color with estimated blue)",
             "scaleExtent": [
                 0,
                 13
@@ -26404,7 +26063,7 @@
             "name": "imagico.de OSM images for mapping: Leskov Island Landsat",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC81991002015286LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC81991002015286LGN00, 2015-10-13, channels 234 (true color), Missing in other image sources",
+            "description": "Missing in other image sources (true color)",
             "scaleExtent": [
                 0,
                 13
@@ -26445,7 +26104,7 @@
             "name": "imagico.de OSM images for mapping: May 2013 off-nadir Landsat",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=ls_polar&z={zoom}&x={x}&y={-y}",
-            "description": "LC80372442013137LGN01-LC80530012013137LGN01, 2013-05-17, channels 234 (true color), First available image north of the regular Landsat limit, mostly with seasonal snow cover so difficult to interpret",
+            "description": "First available image north of the regular Landsat limit, mostly with seasonal snow cover so difficult to interpret (true color)",
             "scaleExtent": [
                 0,
                 10
@@ -26514,7 +26173,7 @@
             "name": "imagico.de OSM images for mapping: Mount Kenya 2016",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R092_S02_20160613T075613&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_OPER_PRD_MSIL1C_PDMC_20160613T140051_R092_V20160613T075613_20160613T075613, 2016-06-13, channels 234 (true color), Up-to-date image for glacier mapping",
+            "description": "Up-to-date image for glacier mapping (true color)",
             "scaleExtent": [
                 0,
                 14
@@ -26551,7 +26210,7 @@
             "name": "imagico.de OSM images for mapping: Mount Kilimanjaro 2016",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R092_S05_20160802T075556&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_OPER_PRD_MSIL1C_PDMC_20160802T130554_R092_V20160802T075556_20160802T075556, 2016-08-02, channels 234 (true color), Up-to-date image for glacier mapping",
+            "description": "Up-to-date image for glacier mapping (true color)",
             "scaleExtent": [
                 0,
                 14
@@ -26588,7 +26247,7 @@
             "name": "imagico.de OSM images for mapping: New Ireland",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC80940622015159LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC80940622015159LGN00, 2015-06-08, channels 234 (true color), Many missing islands in OSM (mostly mapped meanwhile)",
+            "description": "Many missing islands in OSM (mostly mapped meanwhile) (true color)",
             "scaleExtent": [
                 0,
                 14
@@ -26621,11 +26280,56 @@
             "terms_text": "imagico.de OSM images for mapping"
         },
         {
+            "id": "osmim-imagicode-northsea_s2_2016",
+            "name": "imagico.de OSM images for mapping: North Sea Coast 2016",
+            "type": "tms",
+            "template": "http://imagico.de/map/osmim_tiles.php?layer=northsea_s2_2016&z={zoom}&x={x}&y={-y}",
+            "description": "Up-to-date low tide imagery of the coast for updating mapping of tidalflats and shoals (true color)",
+            "scaleExtent": [
+                0,
+                13
+            ],
+            "polygon": [
+                [
+                    [
+                        5.1562,
+                        52.8755
+                    ],
+                    [
+                        5.1615,
+                        53.0325
+                    ],
+                    [
+                        6.4155,
+                        55.7379
+                    ],
+                    [
+                        9.8813,
+                        55.7459
+                    ],
+                    [
+                        9.8813,
+                        53.2428
+                    ],
+                    [
+                        9.6846,
+                        52.8877
+                    ],
+                    [
+                        5.1562,
+                        52.8755
+                    ]
+                ]
+            ],
+            "terms_url": "http://maps.imagico.de/#osmim",
+            "terms_text": "imagico.de OSM images for mapping"
+        },
+        {
             "id": "osmim-imagicode-ural_s2_2016",
             "name": "imagico.de OSM images for mapping: Northern and Polar Ural mountains August 2016",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=ural_s2_2016&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_OPER_PRD_MSIL1C_PDMC_20160812T212938_R092_V20160812T073612_20160812T073615/S2A_OPER_PRD_MSIL1C_PDMC_20160812T222950_R092_V20160812T073612_20160812T073615, 2016-08-12, channels 234 (true color), Up-to-date late summer imagery with few clouds - caution: not all visible snow is glaciers",
+            "description": "Up-to-date late summer imagery with few clouds - caution: not all visible snow is glaciers (true color)",
             "scaleExtent": [
                 0,
                 13
@@ -26670,7 +26374,7 @@
             "name": "imagico.de OSM images for mapping: Northern Ellesmere Island",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=nellesmere_ast&z={zoom}&x={x}&y={-y}",
-            "description": "ASTER L1T, 2012-07-09/2012-07-15, channels 12x (true color with estimated blue), Assembled from July 2012 ASTER imagery",
+            "description": "Assembled from July 2012 ASTER imagery (true color with estimated blue)",
             "scaleExtent": [
                 0,
                 10
@@ -26715,7 +26419,7 @@
             "name": "imagico.de OSM images for mapping: Northern Ellesmere Island July 2016",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=nellesmere_ast_2016&z={zoom}&x={x}&y={-y}",
-            "description": "ASTER L1T, 2012-07-08 to 2012-07-15, channels 12x (true color with estimated blue), Assembled from July 2016 ASTER imagery",
+            "description": "Assembled from July 2016 ASTER imagery (true color with estimated blue)",
             "scaleExtent": [
                 0,
                 10
@@ -26764,7 +26468,7 @@
             "name": "imagico.de OSM images for mapping: Northern German west coast tidalflats",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC81960222015233LGN00vis&z={zoom}&x={x}&y={-y}",
-            "description": "LC81960222015233LGN00, 2015-08-21 channels 134 (true color), Up-to-date low tide imagery of the coast for updating mapping of tidalflats and shoals",
+            "description": "Up-to-date low tide imagery of the coast for updating mapping of tidalflats and shoals (true color)",
             "scaleExtent": [
                 0,
                 12
@@ -26805,7 +26509,7 @@
             "name": "imagico.de OSM images for mapping: Northern German west coast tidalflats (infrared)",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC81960222015233LGN00ir&z={zoom}&x={x}&y={-y}",
-            "description": "LC81960222015233LGN00, 2015-08-21 channel 654 (false color IR), Up-to-date low tide imagery of the coast for updating mapping of tidalflats and shoals",
+            "description": "Up-to-date low tide imagery of the coast for updating mapping of tidalflats and shoals (false color IR)",
             "scaleExtent": [
                 0,
                 12
@@ -26846,7 +26550,7 @@
             "name": "imagico.de OSM images for mapping: Northern Greenland ASTER",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=ngreenland_ast&z={zoom}&x={x}&y={-y}",
-            "description": "ASTER L1T, 2005-06-21 to 2012-08-13, channels 12x (true color with estimated blue), Assembled from mostly 2012 ASTER imagery, some 2005 images mainly in the northeast",
+            "description": "Assembled from mostly 2012 ASTER imagery, some 2005 images mainly in the northeast (true color with estimated blue)",
             "scaleExtent": [
                 0,
                 10
@@ -26903,7 +26607,7 @@
             "name": "imagico.de OSM images for mapping: Northwest Heard Island",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=EO1A1350972013086110KF&z={zoom}&x={x}&y={-y}",
-            "description": "EO1A1350972013086110KF, 2013-03-13, channels 973 (false color IR), Glaciers of Northwest Heard Island (mapped meanwhile)",
+            "description": "Glaciers of Northwest Heard Island (mapped meanwhile) (false color IR)",
             "scaleExtent": [
                 0,
                 13
@@ -26948,7 +26652,7 @@
             "name": "imagico.de OSM images for mapping: Panama Canal",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R111_N09_20160604T154554&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_OPER_PRD_MSIL1C_PDMC_20160607T121312_R111_V20160604T154554_20160604T154554, 2016-06-07, channels 234 (true color), Images of the new locks (but partly cloudy)",
+            "description": "Images of the new locks (but partly cloudy) (true color)",
             "scaleExtent": [
                 0,
                 14
@@ -26985,7 +26689,7 @@
             "name": "imagico.de OSM images for mapping: Panama Canal - Pacific side",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=EO1A0120532016364110KF&z={zoom}&x={x}&y={-y}",
-            "description": "EO1A0120532016364110KF, 2016-12-30, channels 123 (true color), New locks with less clouds than in the Sentinel-2 image - make sure to check image alignment",
+            "description": "New locks with less clouds than in the Sentinel-2 image - make sure to check image alignment (true color)",
             "scaleExtent": [
                 0,
                 14
@@ -27026,11 +26730,68 @@
             "terms_text": "imagico.de OSM images for mapping"
         },
         {
+            "id": "osmim-imagicode-S2A_R078_N68_20160930T081002",
+            "name": "imagico.de OSM images for mapping: Pechora Sea Coast",
+            "type": "tms",
+            "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R078_N68_20160930T081002&z={zoom}&x={x}&y={-y}",
+            "description": "Sentinel-2 image of the Pechora Sea coast in autumn 2016 (true color)",
+            "scaleExtent": [
+                0,
+                13
+            ],
+            "polygon": [
+                [
+                    [
+                        53.1802,
+                        67.5344
+                    ],
+                    [
+                        53.1821,
+                        68.414
+                    ],
+                    [
+                        54.2107,
+                        69.3367
+                    ],
+                    [
+                        55.3584,
+                        70.2786
+                    ],
+                    [
+                        59.004,
+                        70.2786
+                    ],
+                    [
+                        60.6947,
+                        69.977
+                    ],
+                    [
+                        61.9837,
+                        69.7161
+                    ],
+                    [
+                        61.9823,
+                        68.9395
+                    ],
+                    [
+                        59.9153,
+                        67.5344
+                    ],
+                    [
+                        53.1802,
+                        67.5344
+                    ]
+                ]
+            ],
+            "terms_url": "http://maps.imagico.de/#osmim",
+            "terms_text": "imagico.de OSM images for mapping"
+        },
+        {
             "id": "osmim-imagicode-LC81511242016033LGN00",
             "name": "imagico.de OSM images for mapping: Pensacola Mountains",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC81511242016033LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC81511242016033LGN00/LC81511232016033LGN00, 2016-02-02, channels 234 (true color), Outside regular Landsat coverage and therefore not in LIMA and Bing/Mapbox",
+            "description": "Outside regular Landsat coverage and therefore not in LIMA and Bing/Mapbox (true color)",
             "scaleExtent": [
                 0,
                 10
@@ -27075,7 +26836,7 @@
             "name": "imagico.de OSM images for mapping: Prokletije Mountains",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R136_N41_20150831T093006&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_OPER_PRD_MSIL1C_PDMC_20160316T034950_R136_V20150831T093006_20150831T093006, 2015-08-31, channels 234 (true color), Late summer imagery where usual sources are severely limited by clouds and snow",
+            "description": "Late summer imagery where usual sources are severely limited by clouds and snow (true color)",
             "scaleExtent": [
                 0,
                 14
@@ -27112,7 +26873,7 @@
             "name": "imagico.de OSM images for mapping: Qasigiannguit",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=DMS_1142622_03746_20110415_17533956&z={zoom}&x={x}&y={-y}",
-            "description": "DMS_1142622_03746_20110415_17533956, 2011-04-15, true color, Icebridge DMS image of the settlement - alignment might be poor",
+            "description": "Icebridge DMS image of the settlement - alignment might be poor",
             "scaleExtent": [
                 0,
                 15
@@ -27149,7 +26910,7 @@
             "name": "imagico.de OSM images for mapping: Rann of Kutch",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC81510432015030LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "various Landsat early 2015, channel 654 (false color IR), Land/water distinction difficult to properly map based on Bing/Mapbox images",
+            "description": "Land/water distinction difficult to properly map based on Bing/Mapbox images (false color IR)",
             "scaleExtent": [
                 0,
                 12
@@ -27190,7 +26951,7 @@
             "name": "imagico.de OSM images for mapping: Rila and Pirin Mountains",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R093_N41_20150828T092005&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_OPER_PRD_MSIL1C_PDMC_20160412T121341_R093_V20150828T092005_20150828T092005, 2015-08-28, channels 234 (true color), Late summer imagery where usual sources are severely limited by clouds and snow",
+            "description": "Late summer imagery where usual sources are severely limited by clouds and snow (true color)",
             "scaleExtent": [
                 0,
                 14
@@ -27231,7 +26992,7 @@
             "name": "imagico.de OSM images for mapping: Rwenzori Mountains",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC81730602015040LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC81730602015040LGN00, 2015-02-09, channel 654 (false color IR), Recent image of most of the remaining Rwenzori Mountains glaciers",
+            "description": "Recent image of most of the remaining Rwenzori Mountains glaciers (false color IR)",
             "scaleExtent": [
                 0,
                 13
@@ -27268,7 +27029,7 @@
             "name": "imagico.de OSM images for mapping: Rwenzori Mountains 2016",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R078_N01_20160702T082522&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_OPER_PRD_MSIL1C_PDMC_20160702T132847_R078_V20160702T082522_20160702T082522, 2016-07-02, channels 234 (true color), Up-to-date image for glacier mapping",
+            "description": "Up-to-date image for glacier mapping (true color)",
             "scaleExtent": [
                 0,
                 14
@@ -27305,7 +27066,7 @@
             "name": "imagico.de OSM images for mapping: Scott Island",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC80611072014036LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC80611072014036LGN00, 2014-02-05, channels 234 (true color), Missing in other image sources",
+            "description": "Missing in other image sources (true color)",
             "scaleExtent": [
                 0,
                 13
@@ -27342,7 +27103,7 @@
             "name": "imagico.de OSM images for mapping: Shag Rocks",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC82100972015347LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC82100972015347LGN00, 2015-12-13, channels 234 (true color), Missing in other image sources",
+            "description": "Missing in other image sources (true color)",
             "scaleExtent": [
                 0,
                 13
@@ -27379,7 +27140,7 @@
             "name": "imagico.de OSM images for mapping: Southeastern Sulawesi",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC81130622013270LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC81130622013270LGN00, 2013-09-27, channels 234 (true color), Missing islands and coarse coastline due to cloud cover in Bing, lakes could also use additional detail",
+            "description": "Missing islands and coarse coastline due to cloud cover in Bing, lakes could also use additional detail (true color)",
             "scaleExtent": [
                 0,
                 13
@@ -27424,7 +27185,7 @@
             "name": "imagico.de OSM images for mapping: Southern Transantarctic Mountains",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC80281222016035LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC80281222016035LGN00/LC80281212016035LGN00, 2016-02-04, channels 234 (true color), Outside regular Landsat coverage and therefore not in LIMA and Bing/Mapbox",
+            "description": "Outside regular Landsat coverage and therefore not in LIMA and Bing/Mapbox (true color)",
             "scaleExtent": [
                 0,
                 10
@@ -27477,11 +27238,120 @@
             "terms_text": "imagico.de OSM images for mapping"
         },
         {
+            "id": "osmim-imagicode-s2sval",
+            "name": "imagico.de OSM images for mapping: Svalbard mosaic",
+            "type": "tms",
+            "template": "http://imagico.de/map/osmim_tiles.php?layer=s2sval&z={zoom}&x={x}&y={-y}",
+            "description": "Sentinel-2 mosaic of Svalbard (true color)",
+            "scaleExtent": [
+                0,
+                13
+            ],
+            "polygon": [
+                [
+                    [
+                        16.6108,
+                        76.4137
+                    ],
+                    [
+                        16.4731,
+                        76.4268
+                    ],
+                    [
+                        16.3788,
+                        76.4589
+                    ],
+                    [
+                        14.4124,
+                        77.1324
+                    ],
+                    [
+                        14.0784,
+                        77.2536
+                    ],
+                    [
+                        10.9875,
+                        78.4054
+                    ],
+                    [
+                        10.631,
+                        78.5605
+                    ],
+                    [
+                        10.2314,
+                        78.8392
+                    ],
+                    [
+                        10.3952,
+                        79.6074
+                    ],
+                    [
+                        10.516,
+                        79.7731
+                    ],
+                    [
+                        10.9632,
+                        79.8707
+                    ],
+                    [
+                        20.2294,
+                        80.849
+                    ],
+                    [
+                        20.4702,
+                        80.8493
+                    ],
+                    [
+                        25.1752,
+                        80.6817
+                    ],
+                    [
+                        33.4391,
+                        80.3438
+                    ],
+                    [
+                        33.7809,
+                        80.3016
+                    ],
+                    [
+                        34.0395,
+                        80.239
+                    ],
+                    [
+                        33.977,
+                        80.1527
+                    ],
+                    [
+                        25.5722,
+                        76.5917
+                    ],
+                    [
+                        25.2739,
+                        76.481
+                    ],
+                    [
+                        25.1416,
+                        76.4327
+                    ],
+                    [
+                        24.937,
+                        76.4176
+                    ],
+                    [
+                        16.6108,
+                        76.4137
+                    ]
+                ]
+            ],
+            "terms_url": "http://maps.imagico.de/#osmim",
+            "terms_text": "imagico.de OSM images for mapping"
+        },
+        {
             "id": "osmim-imagicode-DMS_1142636_160xx_20110507_1822xxxx",
             "name": "imagico.de OSM images for mapping: Thule Air Base",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=DMS_1142636_160xx_20110507_1822xxxx&z={zoom}&x={x}&y={-y}",
-            "description": "DMS_1142636_16001_20110507_18221638-DMS_1142636_16076_20110507_18224996, 2011-05-07, true color, Icebridge DMS image - alignment might be poor",
+            "description": "Icebridge DMS image - alignment might be poor",
             "scaleExtent": [
                 0,
                 15
@@ -27526,7 +27396,7 @@
             "name": "imagico.de OSM images for mapping: Thule Airbase DMS low altitude overflight September 2015",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=dms_thule2_2015.09.25&z={zoom}&x={x}&y={-y}",
-            "description": "DMS 2015-09-25, true color, Icebridge DMS aerial images from Thule Airbase - alignment might be poor",
+            "description": "Icebridge DMS aerial images from Thule Airbase - alignment might be poor",
             "scaleExtent": [
                 0,
                 17
@@ -27579,7 +27449,7 @@
             "name": "imagico.de OSM images for mapping: Thule Airbase DMS overflight October 2015",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=dms_thule_2015.10.06&z={zoom}&x={x}&y={-y}",
-            "description": "DMS 2015-10-06, true color, Icebridge DMS aerial images from Thule Airbase - alignment might be poor",
+            "description": "Icebridge DMS aerial images from Thule Airbase - alignment might be poor",
             "scaleExtent": [
                 0,
                 16
@@ -27628,7 +27498,7 @@
             "name": "imagico.de OSM images for mapping: Thule Airbase DMS overflight September 2015",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=dms_thule_2015.09.25&z={zoom}&x={x}&y={-y}",
-            "description": "DMS 2015-09-25, true color, Icebridge DMS aerial images from Thule Airbase - alignment might be poor",
+            "description": "Icebridge DMS aerial images from Thule Airbase - alignment might be poor",
             "scaleExtent": [
                 0,
                 16
@@ -27673,7 +27543,7 @@
             "name": "imagico.de OSM images for mapping: Ushakov Island August 2016",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R094_N79_20160812T105622&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_OPER_PRD_MSIL1C_PDMC_20160813T183324_R094_V20160812T105622_20160812T105622, 2016-08-12, channels 234 (true color), Up-to-date late summer imagery with few clouds",
+            "description": "Up-to-date late summer imagery with few clouds (true color)",
             "scaleExtent": [
                 0,
                 12
@@ -27710,7 +27580,7 @@
             "name": "imagico.de OSM images for mapping: Vanatinai",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC80910682014358LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC80910682014358LGN00, 2014-12-24, channels 234 (true color), Coarse coastline due to cloud cover in Bing/Mapbox",
+            "description": "Coarse coastline due to cloud cover in Bing/Mapbox (true color)",
             "scaleExtent": [
                 0,
                 13
@@ -27751,7 +27621,7 @@
             "name": "imagico.de OSM images for mapping: Volcán Calbuco",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC82330892016031LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC82330892016031LGN00, 2016-01-31, channels 234 (true color), Image from after the 2015 eruption",
+            "description": "Image from after the 2015 eruption (true color)",
             "scaleExtent": [
                 0,
                 13
@@ -27792,7 +27662,7 @@
             "name": "imagico.de OSM images for mapping: Vostochny Cosmodrome",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R089_N52_20160623T024048&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_R089_N52_20160623T024048, 2016-06-23, channels 234 (true color), Recent image showing newest features",
+            "description": "Recent image showing newest features (true color)",
             "scaleExtent": [
                 0,
                 13
@@ -27829,7 +27699,7 @@
             "name": "imagico.de OSM images for mapping: Western Karakoram",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=LC81490352013282LGN00&z={zoom}&x={x}&y={-y}",
-            "description": "LC81490352013282LGN00, 2013-10-09, channels 234 (true color), Represents approximately minimum snow cover so can be well used for glacier mapping",
+            "description": "Represents approximately minimum snow cover so can be well used for glacier mapping (true color)",
             "scaleExtent": [
                 0,
                 13
@@ -27866,7 +27736,7 @@
             "name": "imagico.de OSM images for mapping: Willkanuta Mountains and Quelccaya Ice Cap",
             "type": "tms",
             "template": "http://imagico.de/map/osmim_tiles.php?layer=S2A_R039_S15_20160510T145731&z={zoom}&x={x}&y={-y}",
-            "description": "S2A_OPER_PRD_MSIL1C_PDMC_20160511T025410_R039_V20160510T145731_20160510T150701, 2016-05-10, channels 234 (true color), Poor and outdated imagery in other sources",
+            "description": "Poor and outdated imagery in other sources (true color)",
             "scaleExtent": [
                 0,
                 14
@@ -27897,6 +27767,210 @@
             ],
             "terms_url": "http://maps.imagico.de/#osmim",
             "terms_text": "imagico.de OSM images for mapping"
+        },
+        {
+            "id": "IPR-orotofoto-last-tms",
+            "name": "IPR ortofoto LAST (tmsproxy)",
+            "type": "tms",
+            "template": "http://osm-{switch:a,b,c}.zby.cz/tiles_ipr_last.php/{zoom}/{x}/{y}.jpg",
+            "scaleExtent": [
+                1,
+                18
+            ],
+            "polygon": [
+                [
+                    [
+                        14.81231552124,
+                        49.93089301941
+                    ],
+                    [
+                        14.18754582291,
+                        49.87687266984
+                    ],
+                    [
+                        14.12025456314,
+                        50.19881542327
+                    ],
+                    [
+                        14.74502426147,
+                        50.25247461226
+                    ],
+                    [
+                        14.81231552124,
+                        49.93089301941
+                    ]
+                ]
+            ]
+        },
+        {
+            "id": "IPR-orotofoto-vege-tms",
+            "name": "IPR ortofoto Low-Vegetation (tmsproxy)",
+            "type": "tms",
+            "template": "http://osm-{switch:a,b,c}.zby.cz/tiles_ipr_vege.php/{zoom}/{x}/{y}.jpg",
+            "scaleExtent": [
+                1,
+                20
+            ],
+            "polygon": [
+                [
+                    [
+                        14.30454236984,
+                        49.99538124382
+                    ],
+                    [
+                        14.3160436821,
+                        49.94205148763
+                    ],
+                    [
+                        14.3499983888,
+                        49.94508261663
+                    ],
+                    [
+                        14.35383872175,
+                        49.92726356386
+                    ],
+                    [
+                        14.42385321818,
+                        49.93351545169
+                    ],
+                    [
+                        14.4200902288,
+                        49.95097343212
+                    ],
+                    [
+                        14.48865449494,
+                        49.95709281879
+                    ],
+                    [
+                        14.48479036398,
+                        49.9750111737
+                    ],
+                    [
+                        14.55385989188,
+                        49.98117257481
+                    ],
+                    [
+                        14.55011770159,
+                        49.99851689993
+                    ],
+                    [
+                        14.58455395868,
+                        50.0015874108
+                    ],
+                    [
+                        14.58829614897,
+                        49.98424419323
+                    ],
+                    [
+                        14.69168128485,
+                        49.99346468175
+                    ],
+                    [
+                        14.67633637226,
+                        50.06452744171
+                    ],
+                    [
+                        14.71278864961,
+                        50.06777324036
+                    ],
+                    [
+                        14.70115373952,
+                        50.12158114828
+                    ],
+                    [
+                        14.66470146217,
+                        50.11833899243
+                    ],
+                    [
+                        14.6610031918,
+                        50.13543086714
+                    ],
+                    [
+                        14.62755290441,
+                        50.13245658485
+                    ],
+                    [
+                        14.61965341283,
+                        50.16894659259
+                    ],
+                    [
+                        14.58542741996,
+                        50.16590546732
+                    ],
+                    [
+                        14.58162921725,
+                        50.18344165464
+                    ],
+                    [
+                        14.40776267983,
+                        50.167995553
+                    ],
+                    [
+                        14.41156088254,
+                        50.15045369625
+                    ],
+                    [
+                        14.37764851321,
+                        50.14743927281
+                    ],
+                    [
+                        14.37379555571,
+                        50.16523508727
+                    ],
+                    [
+                        14.33892816423,
+                        50.16213672855
+                    ],
+                    [
+                        14.34278112173,
+                        50.14433976066
+                    ],
+                    [
+                        14.27367931007,
+                        50.13819641038
+                    ],
+                    [
+                        14.27749028245,
+                        50.12058459573
+                    ],
+                    [
+                        14.20879964298,
+                        50.11447476994
+                    ],
+                    [
+                        14.21288816219,
+                        50.09557069695
+                    ],
+                    [
+                        14.24656290855,
+                        50.09856724424
+                    ],
+                    [
+                        14.25417384067,
+                        50.06335893014
+                    ],
+                    [
+                        14.21987061144,
+                        50.0603042129
+                    ],
+                    [
+                        14.22369648177,
+                        50.04259477081
+                    ],
+                    [
+                        14.257999711,
+                        50.04565061557
+                    ],
+                    [
+                        14.26952647673,
+                        49.99225864496
+                    ],
+                    [
+                        14.30454236984,
+                        49.99538124382
+                    ]
+                ]
+            ]
         },
         {
             "id": "bartholomew_qi1940",
@@ -28456,24 +28530,640 @@
             "polygon": [
                 [
                     [
-                        7.7,
-                        47.12
+                        8.222923278808594,
+                        47.604774168947614
                     ],
                     [
-                        7.7,
-                        47.63
+                        8.244209289550781,
+                        47.613569753973955
                     ],
                     [
-                        8.5,
-                        47.63
+                        8.294334411621094,
+                        47.60986653003798
                     ],
                     [
-                        8.5,
-                        47.12
+                        8.300857543945312,
+                        47.58625231278527
                     ],
                     [
-                        7.7,
-                        47.12
+                        8.329353332519531,
+                        47.569808674020344
+                    ],
+                    [
+                        8.382568359375,
+                        47.56702895728551
+                    ],
+                    [
+                        8.398017883300781,
+                        47.57490443821351
+                    ],
+                    [
+                        8.424797058105469,
+                        47.56795554592218
+                    ],
+                    [
+                        8.415184020996094,
+                        47.54663986006874
+                    ],
+                    [
+                        8.389778137207031,
+                        47.5262428287156
+                    ],
+                    [
+                        8.372268676757812,
+                        47.51233121261258
+                    ],
+                    [
+                        8.358535766601562,
+                        47.503286684046664
+                    ],
+                    [
+                        8.36402893066406,
+                        47.48078455918
+                    ],
+                    [
+                        8.371238708496094,
+                        47.481016589036074
+                    ],
+                    [
+                        8.373985290527344,
+                        47.47011007802331
+                    ],
+                    [
+                        8.368148803710938,
+                        47.46825342516445
+                    ],
+                    [
+                        8.387031555175781,
+                        47.44852243794931
+                    ],
+                    [
+                        8.380851745605469,
+                        47.447593738482304
+                    ],
+                    [
+                        8.384284973144531,
+                        47.4355191531953
+                    ],
+                    [
+                        8.376388549804688,
+                        47.431803338643334
+                    ],
+                    [
+                        8.377761840820312,
+                        47.42808726171425
+                    ],
+                    [
+                        8.389434814453125,
+                        47.42739046807988
+                    ],
+                    [
+                        8.391494750976562,
+                        47.41902822496511
+                    ],
+                    [
+                        8.380165100097656,
+                        47.40462347023052
+                    ],
+                    [
+                        8.364715576171875,
+                        47.4016026187529
+                    ],
+                    [
+                        8.367118835449219,
+                        47.39881398671558
+                    ],
+                    [
+                        8.380851745605469,
+                        47.39788440990287
+                    ],
+                    [
+                        8.39424133300781,
+                        47.39439835079049
+                    ],
+                    [
+                        8.399734497070312,
+                        47.372314620566925
+                    ],
+                    [
+                        8.40728759765625,
+                        47.37068703239024
+                    ],
+                    [
+                        8.404197692871094,
+                        47.34417352612498
+                    ],
+                    [
+                        8.416213989257812,
+                        47.33416935720614
+                    ],
+                    [
+                        8.414497375488281,
+                        47.32602502961836
+                    ],
+                    [
+                        8.452606201171875,
+                        47.33254059215931
+                    ],
+                    [
+                        8.444023132324219,
+                        47.31927592106609
+                    ],
+                    [
+                        8.427543640136719,
+                        47.29925625338924
+                    ],
+                    [
+                        8.390121459960938,
+                        47.28854494625744
+                    ],
+                    [
+                        8.41175079345703,
+                        47.247076403108416
+                    ],
+                    [
+                        8.393898010253906,
+                        47.227728840642065
+                    ],
+                    [
+                        8.404884338378906,
+                        47.194845099780174
+                    ],
+                    [
+                        8.401451110839844,
+                        47.17757880776958
+                    ],
+                    [
+                        8.409690856933594,
+                        47.17314466448546
+                    ],
+                    [
+                        8.412437438964844,
+                        47.13976002139446
+                    ],
+                    [
+                        8.379478454589844,
+                        47.13929295458033
+                    ],
+                    [
+                        8.361968994140625,
+                        47.14559801038333
+                    ],
+                    [
+                        8.342742919921875,
+                        47.177112073280966
+                    ],
+                    [
+                        8.3056640625,
+                        47.24987305653909
+                    ],
+                    [
+                        8.295021057128906,
+                        47.26268916206698
+                    ],
+                    [
+                        8.300514221191406,
+                        47.26991141830738
+                    ],
+                    [
+                        8.278884887695312,
+                        47.28225686421767
+                    ],
+                    [
+                        8.259315490722656,
+                        47.285983225286174
+                    ],
+                    [
+                        8.243522644042969,
+                        47.280859411143915
+                    ],
+                    [
+                        8.240432739257812,
+                        47.27130916053537
+                    ],
+                    [
+                        8.228759765625,
+                        47.27270686584952
+                    ],
+                    [
+                        8.219146728515625,
+                        47.25336866567523
+                    ],
+                    [
+                        8.204727172851562,
+                        47.245444953748034
+                    ],
+                    [
+                        8.203353881835938,
+                        47.22679624955806
+                    ],
+                    [
+                        8.180007934570312,
+                        47.22143353240336
+                    ],
+                    [
+                        8.171768188476562,
+                        47.2279619858493
+                    ],
+                    [
+                        8.155975341796875,
+                        47.23961793870555
+                    ],
+                    [
+                        8.175888061523436,
+                        47.24218190428504
+                    ],
+                    [
+                        8.17657470703125,
+                        47.25406775981567
+                    ],
+                    [
+                        8.136062622070312,
+                        47.24730946320093
+                    ],
+                    [
+                        8.12164306640625,
+                        47.24218190428504
+                    ],
+                    [
+                        8.10791015625,
+                        47.2447457457832
+                    ],
+                    [
+                        8.097267150878906,
+                        47.259427174956194
+                    ],
+                    [
+                        8.077354431152344,
+                        47.2603591917818
+                    ],
+                    [
+                        8.059844970703125,
+                        47.25569894358661
+                    ],
+                    [
+                        8.062591552734375,
+                        47.24614415248379
+                    ],
+                    [
+                        8.016586303710938,
+                        47.242881146090085
+                    ],
+                    [
+                        8.015899658203125,
+                        47.258961160390896
+                    ],
+                    [
+                        7.997016906738281,
+                        47.2796948387185
+                    ],
+                    [
+                        7.951698303222655,
+                        47.274337475394645
+                    ],
+                    [
+                        7.960968017578125,
+                        47.25430078914495
+                    ],
+                    [
+                        7.933845520019531,
+                        47.237053849043896
+                    ],
+                    [
+                        7.911529541015624,
+                        47.24381345414034
+                    ],
+                    [
+                        7.859344482421875,
+                        47.23425651880584
+                    ],
+                    [
+                        7.83977508544922,
+                        47.23425651880584
+                    ],
+                    [
+                        7.826042175292968,
+                        47.24427960201268
+                    ],
+                    [
+                        7.828102111816407,
+                        47.25966018070071
+                    ],
+                    [
+                        7.82398223876953,
+                        47.26548499105541
+                    ],
+                    [
+                        7.8408050537109375,
+                        47.273405704663965
+                    ],
+                    [
+                        7.848701477050781,
+                        47.28551744450745
+                    ],
+                    [
+                        7.860374450683594,
+                        47.30461109337307
+                    ],
+                    [
+                        7.871704101562499,
+                        47.31136207506936
+                    ],
+                    [
+                        7.8888702392578125,
+                        47.31136207506936
+                    ],
+                    [
+                        7.897453308105469,
+                        47.31904317780638
+                    ],
+                    [
+                        7.895393371582031,
+                        47.327653995607086
+                    ],
+                    [
+                        7.908439636230469,
+                        47.340451266106996
+                    ],
+                    [
+                        7.9259490966796875,
+                        47.332773275955894
+                    ],
+                    [
+                        7.94757843017578,
+                        47.331609846720866
+                    ],
+                    [
+                        7.94757843017578,
+                        47.316715688820764
+                    ],
+                    [
+                        8.007316589355467,
+                        47.33905535093827
+                    ],
+                    [
+                        8.004913330078125,
+                        47.34533667855891
+                    ],
+                    [
+                        8.011093139648438,
+                        47.35719936945847
+                    ],
+                    [
+                        8.024139404296875,
+                        47.36719917429931
+                    ],
+                    [
+                        8.032722473144531,
+                        47.38393878966209
+                    ],
+                    [
+                        8.026885986328125,
+                        47.39602520707679
+                    ],
+                    [
+                        8.010749816894531,
+                        47.3955603961201
+                    ],
+                    [
+                        8.004570007324219,
+                        47.40671472747142
+                    ],
+                    [
+                        7.975730895996094,
+                        47.41507892620099
+                    ],
+                    [
+                        7.9657745361328125,
+                        47.42181578692778
+                    ],
+                    [
+                        7.985343933105469,
+                        47.425764580393924
+                    ],
+                    [
+                        7.971954345703124,
+                        47.46105827584221
+                    ],
+                    [
+                        7.957534790039062,
+                        47.457344265054225
+                    ],
+                    [
+                        7.940711975097656,
+                        47.46221885041022
+                    ],
+                    [
+                        7.946891784667968,
+                        47.48403288391224
+                    ],
+                    [
+                        7.907066345214844,
+                        47.48588897929538
+                    ],
+                    [
+                        7.8936767578125,
+                        47.50653361720931
+                    ],
+                    [
+                        7.873420715332031,
+                        47.51325876844644
+                    ],
+                    [
+                        7.875480651855468,
+                        47.52253342509336
+                    ],
+                    [
+                        7.865180969238281,
+                        47.51975120023913
+                    ],
+                    [
+                        7.856254577636718,
+                        47.533660849056794
+                    ],
+                    [
+                        7.833251953125,
+                        47.5325018525392
+                    ],
+                    [
+                        7.834281921386719,
+                        47.51465007145751
+                    ],
+                    [
+                        7.789649963378906,
+                        47.49377665301097
+                    ],
+                    [
+                        7.789649963378906,
+                        47.518128167602484
+                    ],
+                    [
+                        7.7515411376953125,
+                        47.52461999690649
+                    ],
+                    [
+                        7.731285095214843,
+                        47.53203824675999
+                    ],
+                    [
+                        7.708969116210937,
+                        47.54015075619555
+                    ],
+                    [
+                        7.740898132324219,
+                        47.54362716173679
+                    ],
+                    [
+                        7.761497497558593,
+                        47.54895720250044
+                    ],
+                    [
+                        7.781410217285156,
+                        47.55289644950155
+                    ],
+                    [
+                        7.797546386718749,
+                        47.55915229204993
+                    ],
+                    [
+                        7.805442810058593,
+                        47.56563904359584
+                    ],
+                    [
+                        7.814369201660155,
+                        47.575136052077276
+                    ],
+                    [
+                        7.819175720214843,
+                        47.58648387645128
+                    ],
+                    [
+                        7.8325653076171875,
+                        47.586715439092906
+                    ],
+                    [
+                        7.843208312988281,
+                        47.581620824334166
+                    ],
+                    [
+                        7.859344482421875,
+                        47.58602074809481
+                    ],
+                    [
+                        7.8847503662109375,
+                        47.58764167941513
+                    ],
+                    [
+                        7.903633117675781,
+                        47.58092606572345
+                    ],
+                    [
+                        7.911872863769532,
+                        47.56749225365282
+                    ],
+                    [
+                        7.90740966796875,
+                        47.55776216936179
+                    ],
+                    [
+                        7.917709350585938,
+                        47.545712894408624
+                    ],
+                    [
+                        7.929382324218749,
+                        47.54640812019053
+                    ],
+                    [
+                        7.941741943359374,
+                        47.54432241518175
+                    ],
+                    [
+                        7.9520416259765625,
+                        47.54965238525127
+                    ],
+                    [
+                        7.9561614990234375,
+                        47.55683540041267
+                    ],
+                    [
+                        7.9767608642578125,
+                        47.55544521625339
+                    ],
+                    [
+                        7.997360229492187,
+                        47.556603705614094
+                    ],
+                    [
+                        8.019676208496094,
+                        47.54965238525127
+                    ],
+                    [
+                        8.049888610839844,
+                        47.55637200979099
+                    ],
+                    [
+                        8.058815002441406,
+                        47.56285910557121
+                    ],
+                    [
+                        8.072891235351562,
+                        47.56355410390809
+                    ],
+                    [
+                        8.086967468261719,
+                        47.557067094186735
+                    ],
+                    [
+                        8.100700378417969,
+                        47.56216409801383
+                    ],
+                    [
+                        8.105506896972656,
+                        47.57976811421671
+                    ],
+                    [
+                        8.113059997558594,
+                        47.583473468887405
+                    ],
+                    [
+                        8.133659362792969,
+                        47.58301031389572
+                    ],
+                    [
+                        8.138809204101562,
+                        47.59042030203756
+                    ],
+                    [
+                        8.15185546875,
+                        47.59551406038282
+                    ],
+                    [
+                        8.166275024414062,
+                        47.5941249027327
+                    ],
+                    [
+                        8.177261352539062,
+                        47.6017648134425
+                    ],
+                    [
+                        8.193740844726562,
+                        47.616346999837226
+                    ],
+                    [
+                        8.2012939453125,
+                        47.62120682516921
+                    ],
+                    [
+                        8.219490051269531,
+                        47.61958693358351
+                    ],
+                    [
+                        8.223953247070312,
+                        47.61102381568743
+                    ],
+                    [
+                        8.222923278808594,
+                        47.604774168947614
                     ]
                 ]
             ],
@@ -29128,7 +29818,658 @@
                     ]
                 ]
             ],
-            "terms_text": "AGIS OF2014",
+            "terms_text": "AGIS OF2014"
+        },
+        {
+            "id": "Aargau-AGIS-2016",
+            "name": "Kanton Aargau 25cm (AGIS 2016)",
+            "type": "tms",
+            "template": "http://mapproxy.osm.ch:8080/tiles/AGIS2016/EPSG900913/{zoom}/{x}/{y}.png?origin=nw",
+            "scaleExtent": [
+                8,
+                19
+            ],
+            "polygon": [
+                [
+                    [
+                        8.222923278808594,
+                        47.604774168947614
+                    ],
+                    [
+                        8.244209289550781,
+                        47.613569753973955
+                    ],
+                    [
+                        8.294334411621094,
+                        47.60986653003798
+                    ],
+                    [
+                        8.300857543945312,
+                        47.58625231278527
+                    ],
+                    [
+                        8.329353332519531,
+                        47.569808674020344
+                    ],
+                    [
+                        8.382568359375,
+                        47.56702895728551
+                    ],
+                    [
+                        8.398017883300781,
+                        47.57490443821351
+                    ],
+                    [
+                        8.424797058105469,
+                        47.56795554592218
+                    ],
+                    [
+                        8.415184020996094,
+                        47.54663986006874
+                    ],
+                    [
+                        8.389778137207031,
+                        47.5262428287156
+                    ],
+                    [
+                        8.372268676757812,
+                        47.51233121261258
+                    ],
+                    [
+                        8.358535766601562,
+                        47.503286684046664
+                    ],
+                    [
+                        8.36402893066406,
+                        47.48078455918
+                    ],
+                    [
+                        8.371238708496094,
+                        47.481016589036074
+                    ],
+                    [
+                        8.373985290527344,
+                        47.47011007802331
+                    ],
+                    [
+                        8.368148803710938,
+                        47.46825342516445
+                    ],
+                    [
+                        8.387031555175781,
+                        47.44852243794931
+                    ],
+                    [
+                        8.380851745605469,
+                        47.447593738482304
+                    ],
+                    [
+                        8.384284973144531,
+                        47.4355191531953
+                    ],
+                    [
+                        8.376388549804688,
+                        47.431803338643334
+                    ],
+                    [
+                        8.377761840820312,
+                        47.42808726171425
+                    ],
+                    [
+                        8.389434814453125,
+                        47.42739046807988
+                    ],
+                    [
+                        8.391494750976562,
+                        47.41902822496511
+                    ],
+                    [
+                        8.380165100097656,
+                        47.40462347023052
+                    ],
+                    [
+                        8.364715576171875,
+                        47.4016026187529
+                    ],
+                    [
+                        8.367118835449219,
+                        47.39881398671558
+                    ],
+                    [
+                        8.380851745605469,
+                        47.39788440990287
+                    ],
+                    [
+                        8.39424133300781,
+                        47.39439835079049
+                    ],
+                    [
+                        8.399734497070312,
+                        47.372314620566925
+                    ],
+                    [
+                        8.40728759765625,
+                        47.37068703239024
+                    ],
+                    [
+                        8.404197692871094,
+                        47.34417352612498
+                    ],
+                    [
+                        8.416213989257812,
+                        47.33416935720614
+                    ],
+                    [
+                        8.414497375488281,
+                        47.32602502961836
+                    ],
+                    [
+                        8.452606201171875,
+                        47.33254059215931
+                    ],
+                    [
+                        8.444023132324219,
+                        47.31927592106609
+                    ],
+                    [
+                        8.427543640136719,
+                        47.29925625338924
+                    ],
+                    [
+                        8.390121459960938,
+                        47.28854494625744
+                    ],
+                    [
+                        8.41175079345703,
+                        47.247076403108416
+                    ],
+                    [
+                        8.393898010253906,
+                        47.227728840642065
+                    ],
+                    [
+                        8.404884338378906,
+                        47.194845099780174
+                    ],
+                    [
+                        8.401451110839844,
+                        47.17757880776958
+                    ],
+                    [
+                        8.409690856933594,
+                        47.17314466448546
+                    ],
+                    [
+                        8.412437438964844,
+                        47.13976002139446
+                    ],
+                    [
+                        8.379478454589844,
+                        47.13929295458033
+                    ],
+                    [
+                        8.361968994140625,
+                        47.14559801038333
+                    ],
+                    [
+                        8.342742919921875,
+                        47.177112073280966
+                    ],
+                    [
+                        8.3056640625,
+                        47.24987305653909
+                    ],
+                    [
+                        8.295021057128906,
+                        47.26268916206698
+                    ],
+                    [
+                        8.300514221191406,
+                        47.26991141830738
+                    ],
+                    [
+                        8.278884887695312,
+                        47.28225686421767
+                    ],
+                    [
+                        8.259315490722656,
+                        47.285983225286174
+                    ],
+                    [
+                        8.243522644042969,
+                        47.280859411143915
+                    ],
+                    [
+                        8.240432739257812,
+                        47.27130916053537
+                    ],
+                    [
+                        8.228759765625,
+                        47.27270686584952
+                    ],
+                    [
+                        8.219146728515625,
+                        47.25336866567523
+                    ],
+                    [
+                        8.204727172851562,
+                        47.245444953748034
+                    ],
+                    [
+                        8.203353881835938,
+                        47.22679624955806
+                    ],
+                    [
+                        8.180007934570312,
+                        47.22143353240336
+                    ],
+                    [
+                        8.171768188476562,
+                        47.2279619858493
+                    ],
+                    [
+                        8.155975341796875,
+                        47.23961793870555
+                    ],
+                    [
+                        8.175888061523436,
+                        47.24218190428504
+                    ],
+                    [
+                        8.17657470703125,
+                        47.25406775981567
+                    ],
+                    [
+                        8.136062622070312,
+                        47.24730946320093
+                    ],
+                    [
+                        8.12164306640625,
+                        47.24218190428504
+                    ],
+                    [
+                        8.10791015625,
+                        47.2447457457832
+                    ],
+                    [
+                        8.097267150878906,
+                        47.259427174956194
+                    ],
+                    [
+                        8.077354431152344,
+                        47.2603591917818
+                    ],
+                    [
+                        8.059844970703125,
+                        47.25569894358661
+                    ],
+                    [
+                        8.062591552734375,
+                        47.24614415248379
+                    ],
+                    [
+                        8.016586303710938,
+                        47.242881146090085
+                    ],
+                    [
+                        8.015899658203125,
+                        47.258961160390896
+                    ],
+                    [
+                        7.997016906738281,
+                        47.2796948387185
+                    ],
+                    [
+                        7.951698303222655,
+                        47.274337475394645
+                    ],
+                    [
+                        7.960968017578125,
+                        47.25430078914495
+                    ],
+                    [
+                        7.933845520019531,
+                        47.237053849043896
+                    ],
+                    [
+                        7.911529541015624,
+                        47.24381345414034
+                    ],
+                    [
+                        7.859344482421875,
+                        47.23425651880584
+                    ],
+                    [
+                        7.83977508544922,
+                        47.23425651880584
+                    ],
+                    [
+                        7.826042175292968,
+                        47.24427960201268
+                    ],
+                    [
+                        7.828102111816407,
+                        47.25966018070071
+                    ],
+                    [
+                        7.82398223876953,
+                        47.26548499105541
+                    ],
+                    [
+                        7.8408050537109375,
+                        47.273405704663965
+                    ],
+                    [
+                        7.848701477050781,
+                        47.28551744450745
+                    ],
+                    [
+                        7.860374450683594,
+                        47.30461109337307
+                    ],
+                    [
+                        7.871704101562499,
+                        47.31136207506936
+                    ],
+                    [
+                        7.8888702392578125,
+                        47.31136207506936
+                    ],
+                    [
+                        7.897453308105469,
+                        47.31904317780638
+                    ],
+                    [
+                        7.895393371582031,
+                        47.327653995607086
+                    ],
+                    [
+                        7.908439636230469,
+                        47.340451266106996
+                    ],
+                    [
+                        7.9259490966796875,
+                        47.332773275955894
+                    ],
+                    [
+                        7.94757843017578,
+                        47.331609846720866
+                    ],
+                    [
+                        7.94757843017578,
+                        47.316715688820764
+                    ],
+                    [
+                        8.007316589355467,
+                        47.33905535093827
+                    ],
+                    [
+                        8.004913330078125,
+                        47.34533667855891
+                    ],
+                    [
+                        8.011093139648438,
+                        47.35719936945847
+                    ],
+                    [
+                        8.024139404296875,
+                        47.36719917429931
+                    ],
+                    [
+                        8.032722473144531,
+                        47.38393878966209
+                    ],
+                    [
+                        8.026885986328125,
+                        47.39602520707679
+                    ],
+                    [
+                        8.010749816894531,
+                        47.3955603961201
+                    ],
+                    [
+                        8.004570007324219,
+                        47.40671472747142
+                    ],
+                    [
+                        7.975730895996094,
+                        47.41507892620099
+                    ],
+                    [
+                        7.9657745361328125,
+                        47.42181578692778
+                    ],
+                    [
+                        7.985343933105469,
+                        47.425764580393924
+                    ],
+                    [
+                        7.971954345703124,
+                        47.46105827584221
+                    ],
+                    [
+                        7.957534790039062,
+                        47.457344265054225
+                    ],
+                    [
+                        7.940711975097656,
+                        47.46221885041022
+                    ],
+                    [
+                        7.946891784667968,
+                        47.48403288391224
+                    ],
+                    [
+                        7.907066345214844,
+                        47.48588897929538
+                    ],
+                    [
+                        7.8936767578125,
+                        47.50653361720931
+                    ],
+                    [
+                        7.873420715332031,
+                        47.51325876844644
+                    ],
+                    [
+                        7.875480651855468,
+                        47.52253342509336
+                    ],
+                    [
+                        7.865180969238281,
+                        47.51975120023913
+                    ],
+                    [
+                        7.856254577636718,
+                        47.533660849056794
+                    ],
+                    [
+                        7.833251953125,
+                        47.5325018525392
+                    ],
+                    [
+                        7.834281921386719,
+                        47.51465007145751
+                    ],
+                    [
+                        7.789649963378906,
+                        47.49377665301097
+                    ],
+                    [
+                        7.789649963378906,
+                        47.518128167602484
+                    ],
+                    [
+                        7.7515411376953125,
+                        47.52461999690649
+                    ],
+                    [
+                        7.731285095214843,
+                        47.53203824675999
+                    ],
+                    [
+                        7.708969116210937,
+                        47.54015075619555
+                    ],
+                    [
+                        7.740898132324219,
+                        47.54362716173679
+                    ],
+                    [
+                        7.761497497558593,
+                        47.54895720250044
+                    ],
+                    [
+                        7.781410217285156,
+                        47.55289644950155
+                    ],
+                    [
+                        7.797546386718749,
+                        47.55915229204993
+                    ],
+                    [
+                        7.805442810058593,
+                        47.56563904359584
+                    ],
+                    [
+                        7.814369201660155,
+                        47.575136052077276
+                    ],
+                    [
+                        7.819175720214843,
+                        47.58648387645128
+                    ],
+                    [
+                        7.8325653076171875,
+                        47.586715439092906
+                    ],
+                    [
+                        7.843208312988281,
+                        47.581620824334166
+                    ],
+                    [
+                        7.859344482421875,
+                        47.58602074809481
+                    ],
+                    [
+                        7.8847503662109375,
+                        47.58764167941513
+                    ],
+                    [
+                        7.903633117675781,
+                        47.58092606572345
+                    ],
+                    [
+                        7.911872863769532,
+                        47.56749225365282
+                    ],
+                    [
+                        7.90740966796875,
+                        47.55776216936179
+                    ],
+                    [
+                        7.917709350585938,
+                        47.545712894408624
+                    ],
+                    [
+                        7.929382324218749,
+                        47.54640812019053
+                    ],
+                    [
+                        7.941741943359374,
+                        47.54432241518175
+                    ],
+                    [
+                        7.9520416259765625,
+                        47.54965238525127
+                    ],
+                    [
+                        7.9561614990234375,
+                        47.55683540041267
+                    ],
+                    [
+                        7.9767608642578125,
+                        47.55544521625339
+                    ],
+                    [
+                        7.997360229492187,
+                        47.556603705614094
+                    ],
+                    [
+                        8.019676208496094,
+                        47.54965238525127
+                    ],
+                    [
+                        8.049888610839844,
+                        47.55637200979099
+                    ],
+                    [
+                        8.058815002441406,
+                        47.56285910557121
+                    ],
+                    [
+                        8.072891235351562,
+                        47.56355410390809
+                    ],
+                    [
+                        8.086967468261719,
+                        47.557067094186735
+                    ],
+                    [
+                        8.100700378417969,
+                        47.56216409801383
+                    ],
+                    [
+                        8.105506896972656,
+                        47.57976811421671
+                    ],
+                    [
+                        8.113059997558594,
+                        47.583473468887405
+                    ],
+                    [
+                        8.133659362792969,
+                        47.58301031389572
+                    ],
+                    [
+                        8.138809204101562,
+                        47.59042030203756
+                    ],
+                    [
+                        8.15185546875,
+                        47.59551406038282
+                    ],
+                    [
+                        8.166275024414062,
+                        47.5941249027327
+                    ],
+                    [
+                        8.177261352539062,
+                        47.6017648134425
+                    ],
+                    [
+                        8.193740844726562,
+                        47.616346999837226
+                    ],
+                    [
+                        8.2012939453125,
+                        47.62120682516921
+                    ],
+                    [
+                        8.219490051269531,
+                        47.61958693358351
+                    ],
+                    [
+                        8.223953247070312,
+                        47.61102381568743
+                    ],
+                    [
+                        8.222923278808594,
+                        47.604774168947614
+                    ]
+                ]
+            ],
+            "terms_text": "AGIS OF2016",
             "best": true
         },
         {
@@ -32014,10 +33355,651 @@
             ]
         },
         {
+            "id": "LINZ_NZ_Aerial_Imagery",
+            "name": "LINZ NZ Aerial Imagery",
+            "type": "tms",
+            "template": "https://tiles-a.data-cdn.linz.govt.nz/services;key=3197c6d0e5cb494a95d58dc2de3216c2/tiles/v4/set=2/EPSG:3857/{zoom}/{x}/{y}.png",
+            "scaleExtent": [
+                0,
+                21
+            ],
+            "polygon": [
+                [
+                    [
+                        167.2503662109375,
+                        -47.21956811231548
+                    ],
+                    [
+                        167.244873046875,
+                        -47.28016067076474
+                    ],
+                    [
+                        167.5030517578125,
+                        -47.37975438400816
+                    ],
+                    [
+                        168.2501220703125,
+                        -47.15610477504402
+                    ],
+                    [
+                        168.7445068359375,
+                        -46.79629898997744
+                    ],
+                    [
+                        169.3267822265625,
+                        -46.75491661928188
+                    ],
+                    [
+                        169.78271484375,
+                        -46.604167162931844
+                    ],
+                    [
+                        170.4254150390625,
+                        -46.11132565729794
+                    ],
+                    [
+                        170.804443359375,
+                        -45.95114968669139
+                    ],
+                    [
+                        170.9527587890625,
+                        -45.440862671781744
+                    ],
+                    [
+                        171.309814453125,
+                        -44.91035917458493
+                    ],
+                    [
+                        171.40869140625,
+                        -44.39061697878681
+                    ],
+                    [
+                        172.562255859375,
+                        -43.92954993561458
+                    ],
+                    [
+                        172.90283203125,
+                        -43.96909818325171
+                    ],
+                    [
+                        173.1610107421875,
+                        -43.90976594390799
+                    ],
+                    [
+                        173.2598876953125,
+                        -43.69567969789881
+                    ],
+                    [
+                        172.9742431640625,
+                        -43.53660274231031
+                    ],
+                    [
+                        172.760009765625,
+                        -43.37710501700071
+                    ],
+                    [
+                        173.1500244140625,
+                        -43.17714134663171
+                    ],
+                    [
+                        173.704833984375,
+                        -42.63395872267314
+                    ],
+                    [
+                        174.36401367187497,
+                        -41.78360106648077
+                    ],
+                    [
+                        174.320068359375,
+                        -41.409775832009544
+                    ],
+                    [
+                        174.84741210937497,
+                        -41.52914198872309
+                    ],
+                    [
+                        175.0726318359375,
+                        -41.70572851523751
+                    ],
+                    [
+                        175.506591796875,
+                        -41.672911819602085
+                    ],
+                    [
+                        176.2261962890625,
+                        -41.10832999732831
+                    ],
+                    [
+                        176.8304443359375,
+                        -40.42604212826493
+                    ],
+                    [
+                        177.17102050781247,
+                        -39.67337039176559
+                    ],
+                    [
+                        177.0391845703125,
+                        -39.39375459224347
+                    ],
+                    [
+                        177.4456787109375,
+                        -39.18117526158747
+                    ],
+                    [
+                        177.60498046875,
+                        -39.3300485529424
+                    ],
+                    [
+                        177.978515625,
+                        -39.368279149160124
+                    ],
+                    [
+                        178.3355712890625,
+                        -38.65977773071253
+                    ],
+                    [
+                        178.7091064453125,
+                        -37.74465712069938
+                    ],
+                    [
+                        178.626708984375,
+                        -37.54457732085582
+                    ],
+                    [
+                        178.3135986328125,
+                        -37.43125050179357
+                    ],
+                    [
+                        177.6214599609375,
+                        -37.37888785004525
+                    ],
+                    [
+                        177.0391845703125,
+                        -37.39634613318924
+                    ],
+                    [
+                        176.561279296875,
+                        -37.37015718405751
+                    ],
+                    [
+                        176.3360595703125,
+                        -37.05956083025124
+                    ],
+                    [
+                        176.0064697265625,
+                        -36.29741818650809
+                    ],
+                    [
+                        175.6768798828125,
+                        -36.05354012833974
+                    ],
+                    [
+                        174.671630859375,
+                        -35.1782983520012
+                    ],
+                    [
+                        173.1939697265625,
+                        -34.28445325435288
+                    ],
+                    [
+                        172.6776123046875,
+                        -34.234512362369856
+                    ],
+                    [
+                        172.386474609375,
+                        -34.40237742424137
+                    ],
+                    [
+                        172.4798583984375,
+                        -34.71903991764788
+                    ],
+                    [
+                        172.9852294921875,
+                        -35.32184842037683
+                    ],
+                    [
+                        173.56201171875,
+                        -36.142310873529986
+                    ],
+                    [
+                        174.30908203125,
+                        -37.077093191754415
+                    ],
+                    [
+                        174.5562744140625,
+                        -38.052416771864834
+                    ],
+                    [
+                        174.4793701171875,
+                        -38.655488159952995
+                    ],
+                    [
+                        174.3255615234375,
+                        -38.865374851611634
+                    ],
+                    [
+                        173.7982177734375,
+                        -38.95940879245421
+                    ],
+                    [
+                        173.60595703125,
+                        -39.232253141714885
+                    ],
+                    [
+                        173.6993408203125,
+                        -39.56335316582929
+                    ],
+                    [
+                        174.5892333984375,
+                        -39.95606977009003
+                    ],
+                    [
+                        174.9847412109375,
+                        -40.216635475391215
+                    ],
+                    [
+                        174.9847412109375,
+                        -40.49291502689579
+                    ],
+                    [
+                        174.7210693359375,
+                        -40.805493843894155
+                    ],
+                    [
+                        174.1497802734375,
+                        -40.65147128144056
+                    ],
+                    [
+                        173.2818603515625,
+                        -40.43440488077009
+                    ],
+                    [
+                        172.5897216796875,
+                        -40.350730565917885
+                    ],
+                    [
+                        172.0843505859375,
+                        -40.534676780615406
+                    ],
+                    [
+                        171.7657470703125,
+                        -40.826280356677124
+                    ],
+                    [
+                        171.57348632812497,
+                        -41.3974150664646
+                    ],
+                    [
+                        171.2823486328125,
+                        -41.652392884268124
+                    ],
+                    [
+                        170.8758544921875,
+                        -42.53284428171312
+                    ],
+                    [
+                        170.35400390625,
+                        -42.87193842444846
+                    ],
+                    [
+                        168.277587890625,
+                        -43.92954993561458
+                    ],
+                    [
+                        167.6239013671875,
+                        -44.47691085722324
+                    ],
+                    [
+                        166.55273437499997,
+                        -45.38687734827038
+                    ],
+                    [
+                        166.27258300781247,
+                        -45.916765867649
+                    ],
+                    [
+                        166.4813232421875,
+                        -46.22545288226937
+                    ],
+                    [
+                        167.6788330078125,
+                        -46.471916320870406
+                    ],
+                    [
+                        167.2503662109375,
+                        -47.21956811231548
+                    ]
+                ]
+            ],
+            "terms_url": "http://www.linz.govt.nz/data/licensing-and-using-data/attributing-elevation-or-aerial-imagery-data",
+            "terms_text": "Sourced from LINZ CC-BY 3.0",
+            "best": true
+        },
+        {
+            "id": "LINZ_NZ_Topo50_Gridless_Maps",
+            "name": "LINZ NZ Topo50 Gridless Maps",
+            "type": "tms",
+            "template": "https://tiles-a.data-cdn.linz.govt.nz/services;key=3197c6d0e5cb494a95d58dc2de3216c2/tiles/v4/layer=2343/EPSG:3857/{zoom}/{x}/{y}.png",
+            "scaleExtent": [
+                0,
+                21
+            ],
+            "polygon": [
+                [
+                    [
+                        167.2503662109375,
+                        -47.21956811231548
+                    ],
+                    [
+                        167.244873046875,
+                        -47.28016067076474
+                    ],
+                    [
+                        167.5030517578125,
+                        -47.37975438400816
+                    ],
+                    [
+                        168.2501220703125,
+                        -47.15610477504402
+                    ],
+                    [
+                        168.7445068359375,
+                        -46.79629898997744
+                    ],
+                    [
+                        169.3267822265625,
+                        -46.75491661928188
+                    ],
+                    [
+                        169.78271484375,
+                        -46.604167162931844
+                    ],
+                    [
+                        170.4254150390625,
+                        -46.11132565729794
+                    ],
+                    [
+                        170.804443359375,
+                        -45.95114968669139
+                    ],
+                    [
+                        170.9527587890625,
+                        -45.440862671781744
+                    ],
+                    [
+                        171.309814453125,
+                        -44.91035917458493
+                    ],
+                    [
+                        171.40869140625,
+                        -44.39061697878681
+                    ],
+                    [
+                        172.562255859375,
+                        -43.92954993561458
+                    ],
+                    [
+                        172.90283203125,
+                        -43.96909818325171
+                    ],
+                    [
+                        173.1610107421875,
+                        -43.90976594390799
+                    ],
+                    [
+                        173.2598876953125,
+                        -43.69567969789881
+                    ],
+                    [
+                        172.9742431640625,
+                        -43.53660274231031
+                    ],
+                    [
+                        172.760009765625,
+                        -43.37710501700071
+                    ],
+                    [
+                        173.1500244140625,
+                        -43.17714134663171
+                    ],
+                    [
+                        173.704833984375,
+                        -42.63395872267314
+                    ],
+                    [
+                        174.36401367187497,
+                        -41.78360106648077
+                    ],
+                    [
+                        174.320068359375,
+                        -41.409775832009544
+                    ],
+                    [
+                        174.84741210937497,
+                        -41.52914198872309
+                    ],
+                    [
+                        175.0726318359375,
+                        -41.70572851523751
+                    ],
+                    [
+                        175.506591796875,
+                        -41.672911819602085
+                    ],
+                    [
+                        176.2261962890625,
+                        -41.10832999732831
+                    ],
+                    [
+                        176.8304443359375,
+                        -40.42604212826493
+                    ],
+                    [
+                        177.17102050781247,
+                        -39.67337039176559
+                    ],
+                    [
+                        177.0391845703125,
+                        -39.39375459224347
+                    ],
+                    [
+                        177.4456787109375,
+                        -39.18117526158747
+                    ],
+                    [
+                        177.60498046875,
+                        -39.3300485529424
+                    ],
+                    [
+                        177.978515625,
+                        -39.368279149160124
+                    ],
+                    [
+                        178.3355712890625,
+                        -38.65977773071253
+                    ],
+                    [
+                        178.7091064453125,
+                        -37.74465712069938
+                    ],
+                    [
+                        178.626708984375,
+                        -37.54457732085582
+                    ],
+                    [
+                        178.3135986328125,
+                        -37.43125050179357
+                    ],
+                    [
+                        177.6214599609375,
+                        -37.37888785004525
+                    ],
+                    [
+                        177.0391845703125,
+                        -37.39634613318924
+                    ],
+                    [
+                        176.561279296875,
+                        -37.37015718405751
+                    ],
+                    [
+                        176.3360595703125,
+                        -37.05956083025124
+                    ],
+                    [
+                        176.0064697265625,
+                        -36.29741818650809
+                    ],
+                    [
+                        175.6768798828125,
+                        -36.05354012833974
+                    ],
+                    [
+                        174.671630859375,
+                        -35.1782983520012
+                    ],
+                    [
+                        173.1939697265625,
+                        -34.28445325435288
+                    ],
+                    [
+                        172.6776123046875,
+                        -34.234512362369856
+                    ],
+                    [
+                        172.386474609375,
+                        -34.40237742424137
+                    ],
+                    [
+                        172.4798583984375,
+                        -34.71903991764788
+                    ],
+                    [
+                        172.9852294921875,
+                        -35.32184842037683
+                    ],
+                    [
+                        173.56201171875,
+                        -36.142310873529986
+                    ],
+                    [
+                        174.30908203125,
+                        -37.077093191754415
+                    ],
+                    [
+                        174.5562744140625,
+                        -38.052416771864834
+                    ],
+                    [
+                        174.4793701171875,
+                        -38.655488159952995
+                    ],
+                    [
+                        174.3255615234375,
+                        -38.865374851611634
+                    ],
+                    [
+                        173.7982177734375,
+                        -38.95940879245421
+                    ],
+                    [
+                        173.60595703125,
+                        -39.232253141714885
+                    ],
+                    [
+                        173.6993408203125,
+                        -39.56335316582929
+                    ],
+                    [
+                        174.5892333984375,
+                        -39.95606977009003
+                    ],
+                    [
+                        174.9847412109375,
+                        -40.216635475391215
+                    ],
+                    [
+                        174.9847412109375,
+                        -40.49291502689579
+                    ],
+                    [
+                        174.7210693359375,
+                        -40.805493843894155
+                    ],
+                    [
+                        174.1497802734375,
+                        -40.65147128144056
+                    ],
+                    [
+                        173.2818603515625,
+                        -40.43440488077009
+                    ],
+                    [
+                        172.5897216796875,
+                        -40.350730565917885
+                    ],
+                    [
+                        172.0843505859375,
+                        -40.534676780615406
+                    ],
+                    [
+                        171.7657470703125,
+                        -40.826280356677124
+                    ],
+                    [
+                        171.57348632812497,
+                        -41.3974150664646
+                    ],
+                    [
+                        171.2823486328125,
+                        -41.652392884268124
+                    ],
+                    [
+                        170.8758544921875,
+                        -42.53284428171312
+                    ],
+                    [
+                        170.35400390625,
+                        -42.87193842444846
+                    ],
+                    [
+                        168.277587890625,
+                        -43.92954993561458
+                    ],
+                    [
+                        167.6239013671875,
+                        -44.47691085722324
+                    ],
+                    [
+                        166.55273437499997,
+                        -45.38687734827038
+                    ],
+                    [
+                        166.27258300781247,
+                        -45.916765867649
+                    ],
+                    [
+                        166.4813232421875,
+                        -46.22545288226937
+                    ],
+                    [
+                        167.6788330078125,
+                        -46.471916320870406
+                    ],
+                    [
+                        167.2503662109375,
+                        -47.21956811231548
+                    ]
+                ]
+            ],
+            "terms_url": "https://data.linz.govt.nz/layer/2343-nz-mainland-topo50-gridless-maps/",
+            "terms_text": "Sourced from the LINZ Data Service and licensed by LINZ for re-use under the Creative Commons Attribution 3.0 New Zealand licence."
+        },
+        {
             "id": "ORT10LT",
             "name": "Lithuania - NŽT ORT10LT",
             "type": "tms",
-            "template": "http://mapproxy.openmap.lt/ort10lt/g/{zoom}/{x}/{y}.jpeg",
+            "template": "http://ort10lt.openmap.lt/g16/{zoom}/{x}/{y}.jpeg",
             "scaleExtent": [
                 4,
                 18
@@ -33734,7 +35716,7 @@
                 ]
             ],
             "terms_url": "http://spatialservices.finance.nsw.gov.au/mapping_and_imagery/lpi_web_services",
-            "terms_text": "© Land and Property Information 2016"
+            "terms_text": "© Land and Property Information 2017"
         },
         {
             "id": "NSW_LPI_Imagery",
@@ -34090,7 +36072,7 @@
                 ]
             ],
             "terms_url": "http://spatialservices.finance.nsw.gov.au/mapping_and_imagery/lpi_web_services",
-            "terms_text": "© Land and Property Information 2016",
+            "terms_text": "© Land and Property Information 2017",
             "best": true
         },
         {
@@ -34683,13 +36665,13 @@
                 ]
             ],
             "terms_url": "http://spatialservices.finance.nsw.gov.au/mapping_and_imagery/lpi_web_services",
-            "terms_text": "© Land and Property Information 2016"
+            "terms_text": "© Land and Property Information 2017"
         },
         {
             "id": "Mapbox",
             "name": "Mapbox Satellite",
             "type": "tms",
-            "template": "http://{switch:a,b,c}.tiles.mapbox.com/v4/openstreetmap.map-inh7ifmo/{zoom}/{x}/{y}.png?access_token=pk.eyJ1Ijoib3BlbnN0cmVldG1hcCIsImEiOiJncjlmd0t3In0.DmZsIeOW-3x-C5eX-wAqTw",
+            "template": "https://{switch:a,b,c}.tiles.mapbox.com/v4/openstreetmap.map-inh7ifmo/{zoom}/{x}/{y}.png?access_token=pk.eyJ1Ijoib3BlbnN0cmVldG1hcCIsImEiOiJncjlmd0t3In0.DmZsIeOW-3x-C5eX-wAqTw",
             "description": "Satellite and aerial imagery.",
             "scaleExtent": [
                 0,
@@ -34701,7 +36683,7 @@
         },
         {
             "id": "geodata.md.gov-MD_SixInchImagery",
-            "name": "MD 2014 6 Inch Aerial Imagery",
+            "name": "MD Latest 6 Inch Aerial Imagery",
             "type": "tms",
             "template": "http://whoots.mapwarper.net/tms/{zoom}/{x}/{y}/MD_SixInchImagery/http://geodata.md.gov/imap/services/Imagery/MD_SixInchImagery/MapServer/WmsServer",
             "description": "Six Inch resolution aerial imagery for the State of Maryland",
@@ -35778,10 +37760,6 @@
                         41.059086
                     ],
                     [
-                        -74.041049,
-                        41.059086
-                    ],
-                    [
                         -73.890266,
                         40.998039
                     ],
@@ -35796,10 +37774,6 @@
                     [
                         -73.933408,
                         40.882076
-                    ],
-                    [
-                        -73.933408,
-                        40.882075
                     ],
                     [
                         -73.933408,
@@ -35986,28 +37960,8 @@
                         39.750763
                     ],
                     [
-                        -75.466252,
-                        39.750763
-                    ],
-                    [
-                        -75.466252,
-                        39.750763
-                    ],
-                    [
                         -75.466251,
                         39.750764
-                    ],
-                    [
-                        -75.466251,
-                        39.750765
-                    ],
-                    [
-                        -75.466251,
-                        39.750765
-                    ],
-                    [
-                        -75.466251,
-                        39.750765
                     ],
                     [
                         -75.466251,
@@ -36020,10 +37974,6 @@
                     [
                         -75.466249,
                         39.750768
-                    ],
-                    [
-                        -75.466249,
-                        39.750769
                     ],
                     [
                         -75.466249,
@@ -36267,10 +38217,6 @@
                         41.059086
                     ],
                     [
-                        -74.041049,
-                        41.059086
-                    ],
-                    [
                         -73.890266,
                         40.998039
                     ],
@@ -36285,10 +38231,6 @@
                     [
                         -73.933408,
                         40.882076
-                    ],
-                    [
-                        -73.933408,
-                        40.882075
                     ],
                     [
                         -73.933408,
@@ -36475,28 +38417,8 @@
                         39.750763
                     ],
                     [
-                        -75.466252,
-                        39.750763
-                    ],
-                    [
-                        -75.466252,
-                        39.750763
-                    ],
-                    [
                         -75.466251,
                         39.750764
-                    ],
-                    [
-                        -75.466251,
-                        39.750765
-                    ],
-                    [
-                        -75.466251,
-                        39.750765
-                    ],
-                    [
-                        -75.466251,
-                        39.750765
                     ],
                     [
                         -75.466251,
@@ -36509,10 +38431,6 @@
                     [
                         -75.466249,
                         39.750768
-                    ],
-                    [
-                        -75.466249,
-                        39.750769
                     ],
                     [
                         -75.466249,
@@ -44001,7 +45919,7 @@
             "id": "NLSC-EMAP5",
             "name": "NLSC General Map with Contour line",
             "type": "tms",
-            "template": "http://maps.nlsc.gov.tw/S_Maps/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=EMAP5_OPENDATA&STYLE=_null&TILEMATRIXSET=EPSG:3857&TILEMATRIX=EPSG:3857:{zoom}&TILEROW={y}&TILECOL={x}&FORMAT=image/png",
+            "template": "http://wmts.nlsc.gov.tw/wmts/EMAP5_OPENDATA/default/EPSG:3857/{zoom}/{y}/{x}",
             "description": "The emap from Taiwan National Land Surveying and Mapping Center",
             "scaleExtent": [
                 0,
@@ -44514,7 +46432,7 @@
                 ]
             ],
             "terms_url": "http://maps.nlsc.gov.tw/",
-            "terms_text": "NLSC EMAP 2015"
+            "terms_text": "© National Land Surveying and Mapping Center, Taiwan OGDL 1.0"
         },
         {
             "id": "MAPNIK",
@@ -44526,23 +46444,2331 @@
                 0,
                 19
             ],
-            "terms_url": "https://openstreetmap.org/",
+            "terms_url": "https://www.openstreetmap.org/",
             "terms_text": "© OpenStreetMap contributors, CC-BY-SA",
             "default": true
+        },
+        {
+            "id": "OpenStreetMap-turistautak",
+            "name": "OpenStreetMap (turistautak)",
+            "type": "tms",
+            "template": "http://{switch:h,i,j}.tile.openstreetmap.hu/turistautak/{zoom}/{x}/{y}.png",
+            "scaleExtent": [
+                0,
+                18
+            ],
+            "polygon": [
+                [
+                    [
+                        16.1139147,
+                        46.8691038
+                    ],
+                    [
+                        16.1789749,
+                        46.90662
+                    ],
+                    [
+                        16.2000429,
+                        46.9415079
+                    ],
+                    [
+                        16.2217547,
+                        46.9355441
+                    ],
+                    [
+                        16.2462784,
+                        46.9463851
+                    ],
+                    [
+                        16.2553226,
+                        46.9642125
+                    ],
+                    [
+                        16.2764694,
+                        46.9626082
+                    ],
+                    [
+                        16.290583,
+                        47.0139849
+                    ],
+                    [
+                        16.3016199,
+                        46.9992329
+                    ],
+                    [
+                        16.3414618,
+                        46.9965225
+                    ],
+                    [
+                        16.3505162,
+                        47.0106313
+                    ],
+                    [
+                        16.3734016,
+                        46.9985929
+                    ],
+                    [
+                        16.412765,
+                        47.00475
+                    ],
+                    [
+                        16.4332705,
+                        46.9927417
+                    ],
+                    [
+                        16.4478119,
+                        47.003893
+                    ],
+                    [
+                        16.479997,
+                        46.9941169
+                    ],
+                    [
+                        16.5121988,
+                        47.0011695
+                    ],
+                    [
+                        16.4635584,
+                        47.0322699
+                    ],
+                    [
+                        16.4478586,
+                        47.0227481
+                    ],
+                    [
+                        16.439123,
+                        47.029663
+                    ],
+                    [
+                        16.445673,
+                        47.038872
+                    ],
+                    [
+                        16.520323,
+                        47.056103
+                    ],
+                    [
+                        16.473213,
+                        47.0736169
+                    ],
+                    [
+                        16.4637199,
+                        47.09392
+                    ],
+                    [
+                        16.500798,
+                        47.110058
+                    ],
+                    [
+                        16.500035,
+                        47.123295
+                    ],
+                    [
+                        16.5295349,
+                        47.1287419
+                    ],
+                    [
+                        16.5171609,
+                        47.1496938
+                    ],
+                    [
+                        16.454951,
+                        47.1425878
+                    ],
+                    [
+                        16.4648728,
+                        47.1683349
+                    ],
+                    [
+                        16.4555643,
+                        47.1875584
+                    ],
+                    [
+                        16.4305559,
+                        47.1847022
+                    ],
+                    [
+                        16.4195013,
+                        47.1949147
+                    ],
+                    [
+                        16.4189215,
+                        47.2107114
+                    ],
+                    [
+                        16.4371293,
+                        47.2097043
+                    ],
+                    [
+                        16.4426335,
+                        47.2337117
+                    ],
+                    [
+                        16.4313127,
+                        47.2527554
+                    ],
+                    [
+                        16.4671512,
+                        47.2531652
+                    ],
+                    [
+                        16.4892319,
+                        47.2798885
+                    ],
+                    [
+                        16.4646338,
+                        47.3338455
+                    ],
+                    [
+                        16.4337002,
+                        47.3528101
+                    ],
+                    [
+                        16.458513,
+                        47.3670496
+                    ],
+                    [
+                        16.4454619,
+                        47.4070195
+                    ],
+                    [
+                        16.4831657,
+                        47.4093628
+                    ],
+                    [
+                        16.4963821,
+                        47.3892659
+                    ],
+                    [
+                        16.5170941,
+                        47.4100218
+                    ],
+                    [
+                        16.5749054,
+                        47.4054243
+                    ],
+                    [
+                        16.5807291,
+                        47.4191699
+                    ],
+                    [
+                        16.661847,
+                        47.455595
+                    ],
+                    [
+                        16.6706419,
+                        47.47422
+                    ],
+                    [
+                        16.6523395,
+                        47.500342
+                    ],
+                    [
+                        16.6895619,
+                        47.510161
+                    ],
+                    [
+                        16.7147797,
+                        47.540199
+                    ],
+                    [
+                        16.663545,
+                        47.567733
+                    ],
+                    [
+                        16.673199,
+                        47.6049544
+                    ],
+                    [
+                        16.6595343,
+                        47.6061018
+                    ],
+                    [
+                        16.652758,
+                        47.622852
+                    ],
+                    [
+                        16.6314207,
+                        47.6283176
+                    ],
+                    [
+                        16.5739108,
+                        47.619667
+                    ],
+                    [
+                        16.5147382,
+                        47.6461964
+                    ],
+                    [
+                        16.4967504,
+                        47.6393149
+                    ],
+                    [
+                        16.425464,
+                        47.6621679
+                    ],
+                    [
+                        16.4437449,
+                        47.674205
+                    ],
+                    [
+                        16.4480507,
+                        47.6964725
+                    ],
+                    [
+                        16.4746984,
+                        47.6811576
+                    ],
+                    [
+                        16.4872245,
+                        47.6979767
+                    ],
+                    [
+                        16.5521729,
+                        47.7225519
+                    ],
+                    [
+                        16.5363779,
+                        47.736785
+                    ],
+                    [
+                        16.5479799,
+                        47.751544
+                    ],
+                    [
+                        16.6095193,
+                        47.7603722
+                    ],
+                    [
+                        16.6344148,
+                        47.7590843
+                    ],
+                    [
+                        16.65729,
+                        47.7414879
+                    ],
+                    [
+                        16.7209405,
+                        47.7353565
+                    ],
+                    [
+                        16.7534062,
+                        47.6828165
+                    ],
+                    [
+                        16.8301587,
+                        47.681058
+                    ],
+                    [
+                        16.8394284,
+                        47.7045139
+                    ],
+                    [
+                        16.8668943,
+                        47.7211462
+                    ],
+                    [
+                        16.876679,
+                        47.6876452
+                    ],
+                    [
+                        17.0937421,
+                        47.7077706
+                    ],
+                    [
+                        17.0706562,
+                        47.7285366
+                    ],
+                    [
+                        17.0516019,
+                        47.7938499
+                    ],
+                    [
+                        17.0749479,
+                        47.8084997
+                    ],
+                    [
+                        17.047139,
+                        47.8285635
+                    ],
+                    [
+                        17.0519452,
+                        47.8377691
+                    ],
+                    [
+                        17.0105513,
+                        47.8581765
+                    ],
+                    [
+                        17.0163878,
+                        47.8673325
+                    ],
+                    [
+                        17.0857537,
+                        47.8746239
+                    ],
+                    [
+                        17.113171,
+                        47.9271605
+                    ],
+                    [
+                        17.0917133,
+                        47.9342916
+                    ],
+                    [
+                        17.1183782,
+                        47.9601083
+                    ],
+                    [
+                        17.094657,
+                        47.9708775
+                    ],
+                    [
+                        17.2010289,
+                        48.019992
+                    ],
+                    [
+                        17.241769,
+                        48.0224651
+                    ],
+                    [
+                        17.257955,
+                        47.998655
+                    ],
+                    [
+                        17.334651,
+                        47.993125
+                    ],
+                    [
+                        17.4029929,
+                        47.947849
+                    ],
+                    [
+                        17.4539199,
+                        47.8852579
+                    ],
+                    [
+                        17.5267369,
+                        47.865509
+                    ],
+                    [
+                        17.5675779,
+                        47.8151289
+                    ],
+                    [
+                        17.608402,
+                        47.8218859
+                    ],
+                    [
+                        17.7085789,
+                        47.756678
+                    ],
+                    [
+                        17.7798739,
+                        47.739487
+                    ],
+                    [
+                        17.8660959,
+                        47.74575
+                    ],
+                    [
+                        17.9001292,
+                        47.7392633
+                    ],
+                    [
+                        17.946867,
+                        47.744668
+                    ],
+                    [
+                        17.9708709,
+                        47.7578392
+                    ],
+                    [
+                        18.0044103,
+                        47.7463402
+                    ],
+                    [
+                        18.0380583,
+                        47.7576812
+                    ],
+                    [
+                        18.2958774,
+                        47.7314616
+                    ],
+                    [
+                        18.4540681,
+                        47.7651226
+                    ],
+                    [
+                        18.4931553,
+                        47.7527552
+                    ],
+                    [
+                        18.5590761,
+                        47.7659963
+                    ],
+                    [
+                        18.6460866,
+                        47.7590921
+                    ],
+                    [
+                        18.7260691,
+                        47.7890411
+                    ],
+                    [
+                        18.7411784,
+                        47.8138245
+                    ],
+                    [
+                        18.7920013,
+                        47.8230869
+                    ],
+                    [
+                        18.8485417,
+                        47.8167221
+                    ],
+                    [
+                        18.855876,
+                        47.826077
+                    ],
+                    [
+                        18.828014,
+                        47.834291
+                    ],
+                    [
+                        18.8135749,
+                        47.85555
+                    ],
+                    [
+                        18.76353,
+                        47.8716049
+                    ],
+                    [
+                        18.756858,
+                        47.896838
+                    ],
+                    [
+                        18.776746,
+                        47.955092
+                    ],
+                    [
+                        18.7552499,
+                        47.9763469
+                    ],
+                    [
+                        18.8157429,
+                        47.993442
+                    ],
+                    [
+                        18.819998,
+                        48.039676
+                    ],
+                    [
+                        18.833268,
+                        48.048239
+                    ],
+                    [
+                        18.8749364,
+                        48.0470707
+                    ],
+                    [
+                        18.886674,
+                        48.058682
+                    ],
+                    [
+                        18.9089819,
+                        48.051139
+                    ],
+                    [
+                        18.9439039,
+                        48.058865
+                    ],
+                    [
+                        18.9816099,
+                        48.0536009
+                    ],
+                    [
+                        19.0148639,
+                        48.078179
+                    ],
+                    [
+                        19.0585249,
+                        48.0573529
+                    ],
+                    [
+                        19.0843619,
+                        48.072781
+                    ],
+                    [
+                        19.107402,
+                        48.065596
+                    ],
+                    [
+                        19.1352889,
+                        48.074146
+                    ],
+                    [
+                        19.2413679,
+                        48.0536529
+                    ],
+                    [
+                        19.2557819,
+                        48.0715559
+                    ],
+                    [
+                        19.3031119,
+                        48.088711
+                    ],
+                    [
+                        19.3865969,
+                        48.091914
+                    ],
+                    [
+                        19.400018,
+                        48.082304
+                    ],
+                    [
+                        19.454053,
+                        48.101436
+                    ],
+                    [
+                        19.467354,
+                        48.083933
+                    ],
+                    [
+                        19.4944199,
+                        48.109906
+                    ],
+                    [
+                        19.492377,
+                        48.1396639
+                    ],
+                    [
+                        19.5128219,
+                        48.154663
+                    ],
+                    [
+                        19.504518,
+                        48.173443
+                    ],
+                    [
+                        19.528967,
+                        48.190358
+                    ],
+                    [
+                        19.526044,
+                        48.20313
+                    ],
+                    [
+                        19.577502,
+                        48.2160149
+                    ],
+                    [
+                        19.6308263,
+                        48.2500725
+                    ],
+                    [
+                        19.6445239,
+                        48.2391719
+                    ],
+                    [
+                        19.669857,
+                        48.239212
+                    ],
+                    [
+                        19.691219,
+                        48.203894
+                    ],
+                    [
+                        19.721125,
+                        48.201473
+                    ],
+                    [
+                        19.74618,
+                        48.2165119
+                    ],
+                    [
+                        19.7871629,
+                        48.19253
+                    ],
+                    [
+                        19.7987329,
+                        48.19482
+                    ],
+                    [
+                        19.8052829,
+                        48.183733
+                    ],
+                    [
+                        19.782415,
+                        48.165039
+                    ],
+                    [
+                        19.794812,
+                        48.153529
+                    ],
+                    [
+                        19.821331,
+                        48.169081
+                    ],
+                    [
+                        19.8452819,
+                        48.162742
+                    ],
+                    [
+                        19.8551729,
+                        48.178431
+                    ],
+                    [
+                        19.8601309,
+                        48.169409
+                    ],
+                    [
+                        19.898745,
+                        48.1663119
+                    ],
+                    [
+                        19.9145359,
+                        48.146863
+                    ],
+                    [
+                        19.898298,
+                        48.1249019
+                    ],
+                    [
+                        19.937383,
+                        48.131118
+                    ],
+                    [
+                        19.9743939,
+                        48.1660049
+                    ],
+                    [
+                        19.988706,
+                        48.1621679
+                    ],
+                    [
+                        20.029038,
+                        48.1776849
+                    ],
+                    [
+                        20.049449,
+                        48.1671999
+                    ],
+                    [
+                        20.0729859,
+                        48.179606
+                    ],
+                    [
+                        20.0700369,
+                        48.1917019
+                    ],
+                    [
+                        20.1340909,
+                        48.225182
+                    ],
+                    [
+                        20.1331879,
+                        48.253982
+                    ],
+                    [
+                        20.206162,
+                        48.250979
+                    ],
+                    [
+                        20.2038299,
+                        48.261906
+                    ],
+                    [
+                        20.228466,
+                        48.262779
+                    ],
+                    [
+                        20.2349469,
+                        48.279933
+                    ],
+                    [
+                        20.286858,
+                        48.26164
+                    ],
+                    [
+                        20.3257109,
+                        48.272794
+                    ],
+                    [
+                        20.3374649,
+                        48.301667
+                    ],
+                    [
+                        20.3656579,
+                        48.316606
+                    ],
+                    [
+                        20.384077,
+                        48.3511809
+                    ],
+                    [
+                        20.4098349,
+                        48.365857
+                    ],
+                    [
+                        20.402532,
+                        48.382565
+                    ],
+                    [
+                        20.4205349,
+                        48.403858
+                    ],
+                    [
+                        20.416228,
+                        48.418536
+                    ],
+                    [
+                        20.507929,
+                        48.489363
+                    ],
+                    [
+                        20.5065069,
+                        48.534415
+                    ],
+                    [
+                        20.537471,
+                        48.527878
+                    ],
+                    [
+                        20.5464939,
+                        48.544292
+                    ],
+                    [
+                        20.586595,
+                        48.535759
+                    ],
+                    [
+                        20.6538739,
+                        48.561413
+                    ],
+                    [
+                        20.836359,
+                        48.58284
+                    ],
+                    [
+                        20.8378,
+                        48.57421
+                    ],
+                    [
+                        20.8504359,
+                        48.5816329
+                    ],
+                    [
+                        20.8453301,
+                        48.5665046
+                    ],
+                    [
+                        20.8681549,
+                        48.551818
+                    ],
+                    [
+                        20.922323,
+                        48.559453
+                    ],
+                    [
+                        20.9346349,
+                        48.538341
+                    ],
+                    [
+                        20.955882,
+                        48.533963
+                    ],
+                    [
+                        20.9561979,
+                        48.521666
+                    ],
+                    [
+                        20.9815849,
+                        48.5177669
+                    ],
+                    [
+                        21.0151139,
+                        48.532313
+                    ],
+                    [
+                        21.0663209,
+                        48.525894
+                    ],
+                    [
+                        21.1174479,
+                        48.4910549
+                    ],
+                    [
+                        21.1608749,
+                        48.521499
+                    ],
+                    [
+                        21.179634,
+                        48.518232
+                    ],
+                    [
+                        21.221061,
+                        48.537497
+                    ],
+                    [
+                        21.305488,
+                        48.5222489
+                    ],
+                    [
+                        21.313377,
+                        48.550841
+                    ],
+                    [
+                        21.326875,
+                        48.554129
+                    ],
+                    [
+                        21.319384,
+                        48.561201
+                    ],
+                    [
+                        21.4154499,
+                        48.558951
+                    ],
+                    [
+                        21.4226649,
+                        48.578821
+                    ],
+                    [
+                        21.4406099,
+                        48.585104
+                    ],
+                    [
+                        21.514091,
+                        48.551065
+                    ],
+                    [
+                        21.5420199,
+                        48.508395
+                    ],
+                    [
+                        21.6139329,
+                        48.509416
+                    ],
+                    [
+                        21.6201879,
+                        48.469826
+                    ],
+                    [
+                        21.663549,
+                        48.417961
+                    ],
+                    [
+                        21.6645609,
+                        48.392164
+                    ],
+                    [
+                        21.7017409,
+                        48.380695
+                    ],
+                    [
+                        21.711871,
+                        48.357617
+                    ],
+                    [
+                        21.8174139,
+                        48.332787
+                    ],
+                    [
+                        21.8352029,
+                        48.3346409
+                    ],
+                    [
+                        21.837213,
+                        48.363253
+                    ],
+                    [
+                        21.8842979,
+                        48.356047
+                    ],
+                    [
+                        21.8848429,
+                        48.367539
+                    ],
+                    [
+                        21.897883,
+                        48.36256
+                    ],
+                    [
+                        21.8997959,
+                        48.3702229
+                    ],
+                    [
+                        21.9281859,
+                        48.3615969
+                    ],
+                    [
+                        21.9268059,
+                        48.370899
+                    ],
+                    [
+                        21.949198,
+                        48.378728
+                    ],
+                    [
+                        21.994463,
+                        48.377323
+                    ],
+                    [
+                        22.0213259,
+                        48.392749
+                    ],
+                    [
+                        22.0546049,
+                        48.377528
+                    ],
+                    [
+                        22.0764859,
+                        48.387241
+                    ],
+                    [
+                        22.086743,
+                        48.371564
+                    ],
+                    [
+                        22.1359089,
+                        48.380519
+                    ],
+                    [
+                        22.131056,
+                        48.3912329
+                    ],
+                    [
+                        22.152768,
+                        48.3962409
+                    ],
+                    [
+                        22.1561913,
+                        48.4093076
+                    ],
+                    [
+                        22.2125722,
+                        48.4256468
+                    ],
+                    [
+                        22.2371405,
+                        48.4100396
+                    ],
+                    [
+                        22.2654858,
+                        48.4098675
+                    ],
+                    [
+                        22.2398761,
+                        48.3870055
+                    ],
+                    [
+                        22.2675722,
+                        48.3611612
+                    ],
+                    [
+                        22.3178106,
+                        48.3545437
+                    ],
+                    [
+                        22.3132861,
+                        48.3250712
+                    ],
+                    [
+                        22.3372944,
+                        48.3079113
+                    ],
+                    [
+                        22.3384267,
+                        48.2792074
+                    ],
+                    [
+                        22.3847547,
+                        48.2339632
+                    ],
+                    [
+                        22.4006407,
+                        48.249198
+                    ],
+                    [
+                        22.4328384,
+                        48.2525166
+                    ],
+                    [
+                        22.456386,
+                        48.2423109
+                    ],
+                    [
+                        22.4899029,
+                        48.2534237
+                    ],
+                    [
+                        22.4972201,
+                        48.2395546
+                    ],
+                    [
+                        22.5161491,
+                        48.237965
+                    ],
+                    [
+                        22.5311088,
+                        48.2094282
+                    ],
+                    [
+                        22.5711442,
+                        48.1961428
+                    ],
+                    [
+                        22.5616362,
+                        48.1816066
+                    ],
+                    [
+                        22.5982449,
+                        48.144756
+                    ],
+                    [
+                        22.5902763,
+                        48.1073414
+                    ],
+                    [
+                        22.6754492,
+                        48.091997
+                    ],
+                    [
+                        22.7347192,
+                        48.119848
+                    ],
+                    [
+                        22.7576242,
+                        48.1200599
+                    ],
+                    [
+                        22.7703914,
+                        48.1090162
+                    ],
+                    [
+                        22.772319,
+                        48.1218742
+                    ],
+                    [
+                        22.8027688,
+                        48.1221112
+                    ],
+                    [
+                        22.8025285,
+                        48.1070813
+                    ],
+                    [
+                        22.8254256,
+                        48.1175119
+                    ],
+                    [
+                        22.8364365,
+                        48.080249
+                    ],
+                    [
+                        22.8611284,
+                        48.0750312
+                    ],
+                    [
+                        22.8677955,
+                        48.0524256
+                    ],
+                    [
+                        22.8820424,
+                        48.0548053
+                    ],
+                    [
+                        22.8659692,
+                        48.0113165
+                    ],
+                    [
+                        22.835562,
+                        47.9905988
+                    ],
+                    [
+                        22.8407599,
+                        47.9813636
+                    ],
+                    [
+                        22.8725729,
+                        47.9752683
+                    ],
+                    [
+                        22.8697274,
+                        47.9659593
+                    ],
+                    [
+                        22.8915652,
+                        47.9672446
+                    ],
+                    [
+                        22.897435,
+                        47.9540629
+                    ],
+                    [
+                        22.8473299,
+                        47.9077579
+                    ],
+                    [
+                        22.7928135,
+                        47.8908586
+                    ],
+                    [
+                        22.7586924,
+                        47.8941446
+                    ],
+                    [
+                        22.77775,
+                        47.8422508
+                    ],
+                    [
+                        22.7136344,
+                        47.8360928
+                    ],
+                    [
+                        22.6801938,
+                        47.7877527
+                    ],
+                    [
+                        22.6111171,
+                        47.7717455
+                    ],
+                    [
+                        22.5490018,
+                        47.7722246
+                    ],
+                    [
+                        22.4812121,
+                        47.8108886
+                    ],
+                    [
+                        22.4513078,
+                        47.803389
+                    ],
+                    [
+                        22.4313319,
+                        47.7398119
+                    ],
+                    [
+                        22.3566167,
+                        47.7486206
+                    ],
+                    [
+                        22.3177714,
+                        47.7660887
+                    ],
+                    [
+                        22.3176236,
+                        47.7433657
+                    ],
+                    [
+                        22.2851369,
+                        47.7292757
+                    ],
+                    [
+                        22.264325,
+                        47.7310675
+                    ],
+                    [
+                        22.2589955,
+                        47.6979057
+                    ],
+                    [
+                        22.2306796,
+                        47.693196
+                    ],
+                    [
+                        22.1796501,
+                        47.5916115
+                    ],
+                    [
+                        22.1289245,
+                        47.5978984
+                    ],
+                    [
+                        22.0942787,
+                        47.5583628
+                    ],
+                    [
+                        22.0782587,
+                        47.5621299
+                    ],
+                    [
+                        22.0534529,
+                        47.5474795
+                    ],
+                    [
+                        22.0712176,
+                        47.5380742
+                    ],
+                    [
+                        22.0617872,
+                        47.5288029
+                    ],
+                    [
+                        22.0451278,
+                        47.5398919
+                    ],
+                    [
+                        22.0367222,
+                        47.5326653
+                    ],
+                    [
+                        22.0071886,
+                        47.48362
+                    ],
+                    [
+                        22.0327909,
+                        47.4508372
+                    ],
+                    [
+                        22.0238835,
+                        47.3908631
+                    ],
+                    [
+                        22.0119849,
+                        47.3758016
+                    ],
+                    [
+                        21.9627373,
+                        47.381053
+                    ],
+                    [
+                        21.9382461,
+                        47.3725317
+                    ],
+                    [
+                        21.8777922,
+                        47.2857763
+                    ],
+                    [
+                        21.8872845,
+                        47.2730473
+                    ],
+                    [
+                        21.8534909,
+                        47.2397622
+                    ],
+                    [
+                        21.8580662,
+                        47.1873597
+                    ],
+                    [
+                        21.8124804,
+                        47.1667511
+                    ],
+                    [
+                        21.7924092,
+                        47.1059751
+                    ],
+                    [
+                        21.7268258,
+                        47.0983882
+                    ],
+                    [
+                        21.6976037,
+                        47.057915
+                    ],
+                    [
+                        21.6504151,
+                        47.0408303
+                    ],
+                    [
+                        21.6888701,
+                        47.0019977
+                    ],
+                    [
+                        21.6678744,
+                        46.9712337
+                    ],
+                    [
+                        21.6814917,
+                        46.9652089
+                    ],
+                    [
+                        21.6381964,
+                        46.9330487
+                    ],
+                    [
+                        21.5984455,
+                        46.9274708
+                    ],
+                    [
+                        21.6142857,
+                        46.8867275
+                    ],
+                    [
+                        21.6016694,
+                        46.8668202
+                    ],
+                    [
+                        21.520328,
+                        46.8373749
+                    ],
+                    [
+                        21.5186086,
+                        46.8000703
+                    ],
+                    [
+                        21.4831761,
+                        46.7650246
+                    ],
+                    [
+                        21.5263389,
+                        46.7393249
+                    ],
+                    [
+                        21.529369,
+                        46.7209721
+                    ],
+                    [
+                        21.4923253,
+                        46.6859652
+                    ],
+                    [
+                        21.4728438,
+                        46.6959075
+                    ],
+                    [
+                        21.4299047,
+                        46.693937
+                    ],
+                    [
+                        21.4309553,
+                        46.6781367
+                    ],
+                    [
+                        21.4546661,
+                        46.660863
+                    ],
+                    [
+                        21.4162375,
+                        46.6426231
+                    ],
+                    [
+                        21.4097959,
+                        46.6218052
+                    ],
+                    [
+                        21.3657038,
+                        46.6379501
+                    ],
+                    [
+                        21.3300499,
+                        46.6318155
+                    ],
+                    [
+                        21.3139733,
+                        46.617666
+                    ],
+                    [
+                        21.3012351,
+                        46.5908672
+                    ],
+                    [
+                        21.3207905,
+                        46.5828562
+                    ],
+                    [
+                        21.2743045,
+                        46.5407362
+                    ],
+                    [
+                        21.2600254,
+                        46.5021583
+                    ],
+                    [
+                        21.2744188,
+                        46.4767333
+                    ],
+                    [
+                        21.2964506,
+                        46.4762973
+                    ],
+                    [
+                        21.3174343,
+                        46.4507288
+                    ],
+                    [
+                        21.2895176,
+                        46.4154784
+                    ],
+                    [
+                        21.2963256,
+                        46.4069601
+                    ],
+                    [
+                        21.2250116,
+                        46.4136899
+                    ],
+                    [
+                        21.2064214,
+                        46.4033825
+                    ],
+                    [
+                        21.1992563,
+                        46.3479034
+                    ],
+                    [
+                        21.1762269,
+                        46.3357664
+                    ],
+                    [
+                        21.180497,
+                        46.3044494
+                    ],
+                    [
+                        21.1155437,
+                        46.3018529
+                    ],
+                    [
+                        21.1030549,
+                        46.2624637
+                    ],
+                    [
+                        21.0708792,
+                        46.2539014
+                    ],
+                    [
+                        21.0660827,
+                        46.2429394
+                    ],
+                    [
+                        21.0366237,
+                        46.2480392
+                    ],
+                    [
+                        21.0246723,
+                        46.2665329
+                    ],
+                    [
+                        20.960817,
+                        46.2623039
+                    ],
+                    [
+                        20.9465849,
+                        46.2793024
+                    ],
+                    [
+                        20.9250701,
+                        46.2766191
+                    ],
+                    [
+                        20.9218133,
+                        46.2618129
+                    ],
+                    [
+                        20.8732713,
+                        46.2877555
+                    ],
+                    [
+                        20.7756538,
+                        46.2759602
+                    ],
+                    [
+                        20.7490474,
+                        46.2508489
+                    ],
+                    [
+                        20.7618619,
+                        46.204563
+                    ],
+                    [
+                        20.727401,
+                        46.2077485
+                    ],
+                    [
+                        20.7341052,
+                        46.1939355
+                    ],
+                    [
+                        20.7140487,
+                        46.1660531
+                    ],
+                    [
+                        20.6843592,
+                        46.1447802
+                    ],
+                    [
+                        20.6549178,
+                        46.1497739
+                    ],
+                    [
+                        20.6394471,
+                        46.1267602
+                    ],
+                    [
+                        20.5450486,
+                        46.1790935
+                    ],
+                    [
+                        20.5014839,
+                        46.190334
+                    ],
+                    [
+                        20.4949436,
+                        46.1709908
+                    ],
+                    [
+                        20.4592293,
+                        46.1428837
+                    ],
+                    [
+                        20.3975133,
+                        46.1574709
+                    ],
+                    [
+                        20.3685325,
+                        46.1528554
+                    ],
+                    [
+                        20.3557074,
+                        46.1696256
+                    ],
+                    [
+                        20.2968136,
+                        46.1521542
+                    ],
+                    [
+                        20.2549024,
+                        46.1158522
+                    ],
+                    [
+                        20.2484757,
+                        46.1300956
+                    ],
+                    [
+                        20.2330132,
+                        46.1241668
+                    ],
+                    [
+                        20.1817362,
+                        46.1601137
+                    ],
+                    [
+                        20.1364966,
+                        46.1449476
+                    ],
+                    [
+                        20.1009667,
+                        46.1772756
+                    ],
+                    [
+                        20.0636156,
+                        46.1437275
+                    ],
+                    [
+                        20.0346142,
+                        46.1458888
+                    ],
+                    [
+                        20.0158072,
+                        46.1768354
+                    ],
+                    [
+                        19.9354075,
+                        46.1764243
+                    ],
+                    [
+                        19.8533469,
+                        46.1500005
+                    ],
+                    [
+                        19.8179747,
+                        46.1281652
+                    ],
+                    [
+                        19.7585403,
+                        46.1479754
+                    ],
+                    [
+                        19.6982054,
+                        46.1879317
+                    ],
+                    [
+                        19.6827672,
+                        46.1800388
+                    ],
+                    [
+                        19.661508,
+                        46.1904394
+                    ],
+                    [
+                        19.6317396,
+                        46.1692993
+                    ],
+                    [
+                        19.5676482,
+                        46.179106
+                    ],
+                    [
+                        19.5604013,
+                        46.1665762
+                    ],
+                    [
+                        19.5026585,
+                        46.1424492
+                    ],
+                    [
+                        19.5271208,
+                        46.1210269
+                    ],
+                    [
+                        19.4645033,
+                        46.0953827
+                    ],
+                    [
+                        19.4665828,
+                        46.0820437
+                    ],
+                    [
+                        19.4160037,
+                        46.0460453
+                    ],
+                    [
+                        19.3803957,
+                        46.0358749
+                    ],
+                    [
+                        19.3640923,
+                        46.0522965
+                    ],
+                    [
+                        19.2819012,
+                        46.0148048
+                    ],
+                    [
+                        19.2965348,
+                        45.9881173
+                    ],
+                    [
+                        19.2856472,
+                        45.9968981
+                    ],
+                    [
+                        19.1479857,
+                        45.9963445
+                    ],
+                    [
+                        19.1338422,
+                        46.0370993
+                    ],
+                    [
+                        19.104873,
+                        46.0401673
+                    ],
+                    [
+                        19.0660427,
+                        46.0001999
+                    ],
+                    [
+                        19.0796791,
+                        45.9636376
+                    ],
+                    [
+                        19.0059803,
+                        45.9590674
+                    ],
+                    [
+                        19.0092745,
+                        45.9236559
+                    ],
+                    [
+                        18.9061334,
+                        45.9353801
+                    ],
+                    [
+                        18.8794572,
+                        45.9166827
+                    ],
+                    [
+                        18.8647137,
+                        45.9208493
+                    ],
+                    [
+                        18.8685629,
+                        45.9113361
+                    ],
+                    [
+                        18.8276792,
+                        45.9051714
+                    ],
+                    [
+                        18.8220041,
+                        45.9145893
+                    ],
+                    [
+                        18.8075092,
+                        45.9036055
+                    ],
+                    [
+                        18.809247,
+                        45.8796189
+                    ],
+                    [
+                        18.7956242,
+                        45.8784488
+                    ],
+                    [
+                        18.7048857,
+                        45.9181883
+                    ],
+                    [
+                        18.6700246,
+                        45.9108439
+                    ],
+                    [
+                        18.6596602,
+                        45.9168934
+                    ],
+                    [
+                        18.6651348,
+                        45.899279
+                    ],
+                    [
+                        18.6412808,
+                        45.8890396
+                    ],
+                    [
+                        18.6550179,
+                        45.8742393
+                    ],
+                    [
+                        18.6277704,
+                        45.8733782
+                    ],
+                    [
+                        18.6148449,
+                        45.8531438
+                    ],
+                    [
+                        18.6236656,
+                        45.8398531
+                    ],
+                    [
+                        18.5732391,
+                        45.8137578
+                    ],
+                    [
+                        18.5749849,
+                        45.8004344
+                    ],
+                    [
+                        18.559716,
+                        45.8037961
+                    ],
+                    [
+                        18.5223504,
+                        45.7826858
+                    ],
+                    [
+                        18.4906706,
+                        45.7947167
+                    ],
+                    [
+                        18.4821905,
+                        45.7655032
+                    ],
+                    [
+                        18.4562828,
+                        45.7695229
+                    ],
+                    [
+                        18.4450763,
+                        45.7605195
+                    ],
+                    [
+                        18.446853,
+                        45.737128
+                    ],
+                    [
+                        18.40763,
+                        45.7397119
+                    ],
+                    [
+                        18.3918949,
+                        45.7616983
+                    ],
+                    [
+                        18.3642257,
+                        45.7729364
+                    ],
+                    [
+                        18.3394214,
+                        45.7471605
+                    ],
+                    [
+                        18.2968157,
+                        45.7612196
+                    ],
+                    [
+                        18.2440473,
+                        45.7612305
+                    ],
+                    [
+                        18.2307311,
+                        45.7790328
+                    ],
+                    [
+                        18.1908702,
+                        45.7878759
+                    ],
+                    [
+                        18.1681939,
+                        45.7762712
+                    ],
+                    [
+                        18.1246514,
+                        45.7896277
+                    ],
+                    [
+                        18.1068067,
+                        45.7708256
+                    ],
+                    [
+                        18.0818922,
+                        45.7645205
+                    ],
+                    [
+                        17.9958808,
+                        45.7957311
+                    ],
+                    [
+                        17.9302095,
+                        45.7863301
+                    ],
+                    [
+                        17.9066757,
+                        45.7925692
+                    ],
+                    [
+                        17.8653145,
+                        45.7670064
+                    ],
+                    [
+                        17.8262748,
+                        45.8099957
+                    ],
+                    [
+                        17.8089784,
+                        45.8040989
+                    ],
+                    [
+                        17.7809054,
+                        45.8174884
+                    ],
+                    [
+                        17.7603399,
+                        45.811923
+                    ],
+                    [
+                        17.7408624,
+                        45.8295975
+                    ],
+                    [
+                        17.6632915,
+                        45.8381849
+                    ],
+                    [
+                        17.6276211,
+                        45.8979446
+                    ],
+                    [
+                        17.5700676,
+                        45.9358204
+                    ],
+                    [
+                        17.4378254,
+                        45.9503823
+                    ],
+                    [
+                        17.4258964,
+                        45.9272681
+                    ],
+                    [
+                        17.4108059,
+                        45.9399665
+                    ],
+                    [
+                        17.392149,
+                        45.9302149
+                    ],
+                    [
+                        17.3828713,
+                        45.9475733
+                    ],
+                    [
+                        17.3476208,
+                        45.9423413
+                    ],
+                    [
+                        17.3438769,
+                        45.9605329
+                    ],
+                    [
+                        17.3537711,
+                        45.9525011
+                    ],
+                    [
+                        17.3905375,
+                        45.9581914
+                    ],
+                    [
+                        17.387423,
+                        45.9661823
+                    ],
+                    [
+                        17.3583539,
+                        45.9642737
+                    ],
+                    [
+                        17.3754852,
+                        45.9686921
+                    ],
+                    [
+                        17.3751895,
+                        45.9881054
+                    ],
+                    [
+                        17.3635685,
+                        45.9915442
+                    ],
+                    [
+                        17.3567202,
+                        45.9735836
+                    ],
+                    [
+                        17.3339583,
+                        45.9960781
+                    ],
+                    [
+                        17.3319847,
+                        45.9728948
+                    ],
+                    [
+                        17.3129974,
+                        45.9665347
+                    ],
+                    [
+                        17.323647,
+                        45.9887776
+                    ],
+                    [
+                        17.2987653,
+                        45.9838652
+                    ],
+                    [
+                        17.3041996,
+                        46.0021128
+                    ],
+                    [
+                        17.2579726,
+                        46.0110256
+                    ],
+                    [
+                        17.29632,
+                        46.0285169
+                    ],
+                    [
+                        17.2541514,
+                        46.030005
+                    ],
+                    [
+                        17.270955,
+                        46.0567055
+                    ],
+                    [
+                        17.2324767,
+                        46.0592034
+                    ],
+                    [
+                        17.2525145,
+                        46.0664725
+                    ],
+                    [
+                        17.2313144,
+                        46.0790345
+                    ],
+                    [
+                        17.2019916,
+                        46.0765488
+                    ],
+                    [
+                        17.2331299,
+                        46.0989644
+                    ],
+                    [
+                        17.2104017,
+                        46.1001693
+                    ],
+                    [
+                        17.2129734,
+                        46.113855
+                    ],
+                    [
+                        17.175927,
+                        46.1084583
+                    ],
+                    [
+                        17.1743424,
+                        46.1287608
+                    ],
+                    [
+                        17.1865197,
+                        46.1332308
+                    ],
+                    [
+                        17.1810983,
+                        46.1505485
+                    ],
+                    [
+                        17.1562307,
+                        46.1585819
+                    ],
+                    [
+                        17.1592857,
+                        46.1696818
+                    ],
+                    [
+                        17.1261012,
+                        46.1684495
+                    ],
+                    [
+                        17.1227409,
+                        46.1789791
+                    ],
+                    [
+                        17.0752482,
+                        46.1889531
+                    ],
+                    [
+                        17.0661614,
+                        46.2022984
+                    ],
+                    [
+                        16.9735401,
+                        46.2251982
+                    ],
+                    [
+                        16.973954,
+                        46.2431113
+                    ],
+                    [
+                        16.9504085,
+                        46.2415285
+                    ],
+                    [
+                        16.8862356,
+                        46.2814598
+                    ],
+                    [
+                        16.8713682,
+                        46.3252767
+                    ],
+                    [
+                        16.8802109,
+                        46.3356966
+                    ],
+                    [
+                        16.8615374,
+                        46.3452401
+                    ],
+                    [
+                        16.8656232,
+                        46.3556489
+                    ],
+                    [
+                        16.8521959,
+                        46.3517189
+                    ],
+                    [
+                        16.8498589,
+                        46.3626245
+                    ],
+                    [
+                        16.8352859,
+                        46.3638195
+                    ],
+                    [
+                        16.8376499,
+                        46.3748032
+                    ],
+                    [
+                        16.8261732,
+                        46.3670994
+                    ],
+                    [
+                        16.7933444,
+                        46.387385
+                    ],
+                    [
+                        16.7592072,
+                        46.3776563
+                    ],
+                    [
+                        16.7298672,
+                        46.40149
+                    ],
+                    [
+                        16.7182119,
+                        46.3898704
+                    ],
+                    [
+                        16.6772872,
+                        46.4494536
+                    ],
+                    [
+                        16.6631785,
+                        46.4486958
+                    ],
+                    [
+                        16.6663732,
+                        46.4582995
+                    ],
+                    [
+                        16.6187915,
+                        46.4619875
+                    ],
+                    [
+                        16.604468,
+                        46.4760773
+                    ],
+                    [
+                        16.5235997,
+                        46.5053761
+                    ],
+                    [
+                        16.5325768,
+                        46.5314027
+                    ],
+                    [
+                        16.5176728,
+                        46.5363516
+                    ],
+                    [
+                        16.5084107,
+                        46.5652692
+                    ],
+                    [
+                        16.4829969,
+                        46.5660383
+                    ],
+                    [
+                        16.4834008,
+                        46.5786011
+                    ],
+                    [
+                        16.4455713,
+                        46.610952
+                    ],
+                    [
+                        16.4248583,
+                        46.6131645
+                    ],
+                    [
+                        16.385941,
+                        46.6442485
+                    ],
+                    [
+                        16.3915424,
+                        46.6637257
+                    ],
+                    [
+                        16.4198454,
+                        46.6584771
+                    ],
+                    [
+                        16.4286335,
+                        46.6939737
+                    ],
+                    [
+                        16.3689211,
+                        46.7040082
+                    ],
+                    [
+                        16.3798266,
+                        46.7153869
+                    ],
+                    [
+                        16.3710856,
+                        46.7222945
+                    ],
+                    [
+                        16.3570587,
+                        46.7142387
+                    ],
+                    [
+                        16.3185954,
+                        46.7541449
+                    ],
+                    [
+                        16.3305417,
+                        46.7752119
+                    ],
+                    [
+                        16.3121626,
+                        46.7780033
+                    ],
+                    [
+                        16.3127666,
+                        46.797314
+                    ],
+                    [
+                        16.3406373,
+                        46.8051851
+                    ],
+                    [
+                        16.3508404,
+                        46.8300552
+                    ],
+                    [
+                        16.3403309,
+                        46.8468762
+                    ],
+                    [
+                        16.3015007,
+                        46.8595142
+                    ],
+                    [
+                        16.2913867,
+                        46.8728341
+                    ],
+                    [
+                        16.2332296,
+                        46.8766702
+                    ],
+                    [
+                        16.1560866,
+                        46.8537074
+                    ],
+                    [
+                        16.126571,
+                        46.8569079
+                    ],
+                    [
+                        16.1139147,
+                        46.8691038
+                    ]
+                ]
+            ],
+            "terms_url": "https://www.openstreetmap.org/",
+            "terms_text": "© OpenStreetMap contributors"
         },
         {
             "id": "osm-gps",
             "name": "OpenStreetMap GPS traces",
             "type": "tms",
-            "template": "http://{switch:a,b,c}.gps-tile.openstreetmap.org/lines/{zoom}/{x}/{y}.png",
+            "template": "https://{switch:a,b,c}.gps-tile.openstreetmap.org/lines/{zoom}/{x}/{y}.png",
             "description": "Public GPS traces uploaded to OpenStreetMap.",
             "scaleExtent": [
                 0,
                 20
             ],
-            "terms_url": "http://www.openstreetmap.org/copyright",
+            "terms_url": "https://www.openstreetmap.org/copyright",
             "terms_text": "© OpenStreetMap contributors",
-            "terms_html": "<span style='display: inline-block; padding: 0 8px; background-color: rgba(0,0,0,0.5);'><span style='color: #eee;'>GPS Direction:</span> <span style='font-size: 15px; padding-left: 2px; font-weight: bold;'> <span style='color: #0ee;'>&larr;</span> <span style='color: #96f;'>&darr;</span> <span style='color: #6e0;'>&uarr;</span> <span style='color: #f63;'>&rarr;</span> </span></span> © <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>.",
+            "terms_html": "<span style='display: inline-block; padding: 0 8px; background-color: rgba(0,0,0,0.5);'><span style='color: #eee;'>GPS Direction:</span> <span style='font-size: 15px; padding-left: 2px; font-weight: bold;'> <span style='color: #0ee;'>&larr;</span> <span style='color: #96f;'>&darr;</span> <span style='color: #6e0;'>&uarr;</span> <span style='color: #f63;'>&rarr;</span> </span></span> © <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>.",
             "overlay": true
         },
         {
@@ -45462,7 +49688,7 @@
                     ]
                 ]
             ],
-            "terms_url": "https://data.public.lu/en/datasets/bd-l-ortho-webservices-wms-et-wmts",
+            "terms_url": "https://data.public.lu/en/datasets/bd-l-ortho-webservices-wms-et-wmts/",
             "terms_text": "Administration du Cadastre et de la Topographie"
         },
         {
@@ -46382,7 +50608,7 @@
                     ]
                 ]
             ],
-            "terms_url": "https://data.public.lu/en/datasets/bd-l-ortho-webservices-wms-et-wmts",
+            "terms_url": "https://data.public.lu/en/datasets/bd-l-ortho-webservices-wms-et-wmts/",
             "terms_text": "Administration du Cadastre et de la Topographie"
         },
         {
@@ -47302,7 +51528,7 @@
                     ]
                 ]
             ],
-            "terms_url": "https://data.public.lu/en/datasets/bd-l-ortho-webservices-wms-et-wmts",
+            "terms_url": "https://data.public.lu/en/datasets/bd-l-ortho-webservices-wms-et-wmts/",
             "terms_text": "Administration du Cadastre et de la Topographie",
             "best": true
         },
@@ -49593,7 +53819,7 @@
         },
         {
             "id": "Pangasinan_Bulacan_HiRes",
-            "name": "Pangasinán/Bulacan (Phillipines HiRes)",
+            "name": "Pangasinán/Bulacan (Philippines HiRes)",
             "type": "tms",
             "template": "http://gravitystorm.dev.openstreetmap.org/imagery/philippines/{zoom}/{x}/{y}.png",
             "scaleExtent": [
@@ -49666,6 +53892,244 @@
                     ]
                 ]
             ]
+        },
+        {
+            "id": "Actueel_ortho25_WMTS",
+            "name": "PDOK Luchtfoto Beeldmateriaal 25cm",
+            "type": "tms",
+            "template": "http://geodata.nationaalgeoregister.nl/luchtfoto/wmts?FORMAT=image/jpeg&SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=2016_ortho25&STYLE=&FORMAT=image/jpeg&tileMatrixSet=OGC:1.0:GoogleMapsCompatible&tileMatrix={zoom}&tileRow={y}&tileCol={x}",
+            "description": "Landsdekkende dataset 25cm resolutie kleuren luchtfotos van de meest recente jaargang.",
+            "scaleExtent": [
+                0,
+                18
+            ],
+            "polygon": [
+                [
+                    [
+                        3.1437689,
+                        51.3598403
+                    ],
+                    [
+                        3.1575018,
+                        51.2411346
+                    ],
+                    [
+                        3.3387762,
+                        51.1154412
+                    ],
+                    [
+                        3.9128119,
+                        51.0585083
+                    ],
+                    [
+                        4.6571356,
+                        51.2806657
+                    ],
+                    [
+                        4.8933416,
+                        51.2634825
+                    ],
+                    [
+                        5.1789862,
+                        51.1257851
+                    ],
+                    [
+                        5.3849798,
+                        51.1309561
+                    ],
+                    [
+                        5.5442816,
+                        51.056782
+                    ],
+                    [
+                        5.4206854,
+                        50.8595581
+                    ],
+                    [
+                        5.4673773,
+                        50.7032633
+                    ],
+                    [
+                        5.6568914,
+                        50.6192567
+                    ],
+                    [
+                        6.1485296,
+                        50.6214349
+                    ],
+                    [
+                        6.3023382,
+                        50.8578243
+                    ],
+                    [
+                        6.2995916,
+                        50.9543819
+                    ],
+                    [
+                        6.2638861,
+                        51.0183545
+                    ],
+                    [
+                        6.3723761,
+                        51.0925902
+                    ],
+                    [
+                        6.4012152,
+                        51.2011393
+                    ],
+                    [
+                        6.3737494,
+                        51.2510206
+                    ],
+                    [
+                        6.4451605,
+                        51.3158713
+                    ],
+                    [
+                        6.4204413,
+                        51.5496009
+                    ],
+                    [
+                        6.343537,
+                        51.6792182
+                    ],
+                    [
+                        6.796723,
+                        51.7642909
+                    ],
+                    [
+                        7.046662,
+                        51.9102418
+                    ],
+                    [
+                        7.0713812,
+                        52.0455856
+                    ],
+                    [
+                        7.2718817,
+                        52.1704147
+                    ],
+                    [
+                        7.3075872,
+                        52.3855111
+                    ],
+                    [
+                        7.2059637,
+                        52.5319494
+                    ],
+                    [
+                        7.282868,
+                        52.614576
+                    ],
+                    [
+                        7.2993475,
+                        52.7785318
+                    ],
+                    [
+                        7.4421698,
+                        52.9782705
+                    ],
+                    [
+                        7.43393,
+                        53.2831352
+                    ],
+                    [
+                        7.0439154,
+                        53.5515877
+                    ],
+                    [
+                        6.7829901,
+                        53.6363531
+                    ],
+                    [
+                        6.2391668,
+                        53.5401639
+                    ],
+                    [
+                        5.6871039,
+                        53.5124077
+                    ],
+                    [
+                        5.173493,
+                        53.4388477
+                    ],
+                    [
+                        4.8164373,
+                        53.2338445
+                    ],
+                    [
+                        4.6516424,
+                        53.0658312
+                    ],
+                    [
+                        4.5417791,
+                        52.4859784
+                    ],
+                    [
+                        4.3220526,
+                        52.1956753
+                    ],
+                    [
+                        4.08104,
+                        52.0136897
+                    ],
+                    [
+                        4.0219885,
+                        52.0162253
+                    ],
+                    [
+                        3.9368445,
+                        51.9637937
+                    ],
+                    [
+                        3.9519507,
+                        51.8807927
+                    ],
+                    [
+                        3.844834,
+                        51.8494157
+                    ],
+                    [
+                        3.6237341,
+                        51.7075226
+                    ],
+                    [
+                        3.6553198,
+                        51.6606936
+                    ],
+                    [
+                        3.6333471,
+                        51.6274583
+                    ],
+                    [
+                        3.5468298,
+                        51.622343
+                    ],
+                    [
+                        3.3957678,
+                        51.5609145
+                    ],
+                    [
+                        3.3820349,
+                        51.5173524
+                    ],
+                    [
+                        3.4987646,
+                        51.4326715
+                    ],
+                    [
+                        3.3298498,
+                        51.3855587
+                    ],
+                    [
+                        3.1437689,
+                        51.3598403
+                    ]
+                ]
+            ],
+            "terms_url": "http://www.nationaalgeoregister.nl/geonetwork/srv/dut/catalog.search#/search?facet.q=license%2FCC-BY&isChild=%27false%27&resultType=details&any_OR_title_OR_keyword=luchtfoto&fast=index&_content_type=json&from=1&to=20&sortBy=relevance",
+            "terms_text": "Kadaster / Beeldmateriaal.nl, CC BY 4.0",
+            "best": true
         },
         {
             "id": "PNOA-Spain-TMS",
@@ -52008,6 +56472,651 @@
             "best": true
         },
         {
+            "id": "Geodatastyrelsen_Denmark",
+            "name": "SDFE aerial imagery",
+            "type": "tms",
+            "template": "http://osmtools.septima.dk/mapproxy/tiles/1.0.0/kortforsyningen_ortoforaar/EPSG3857/{zoom}/{x}/{y}.jpeg",
+            "scaleExtent": [
+                0,
+                21
+            ],
+            "polygon": [
+                [
+                    [
+                        8.3743941,
+                        54.9551655
+                    ],
+                    [
+                        8.3683809,
+                        55.4042149
+                    ],
+                    [
+                        8.2103997,
+                        55.4039795
+                    ],
+                    [
+                        8.2087314,
+                        55.4937345
+                    ],
+                    [
+                        8.0502655,
+                        55.4924731
+                    ],
+                    [
+                        8.0185123,
+                        56.7501399
+                    ],
+                    [
+                        8.1819161,
+                        56.7509948
+                    ],
+                    [
+                        8.1763274,
+                        57.0208898
+                    ],
+                    [
+                        8.3413329,
+                        57.0219872
+                    ],
+                    [
+                        8.3392467,
+                        57.1119574
+                    ],
+                    [
+                        8.5054433,
+                        57.1123212
+                    ],
+                    [
+                        8.5033923,
+                        57.2020499
+                    ],
+                    [
+                        9.3316304,
+                        57.2027636
+                    ],
+                    [
+                        9.3319079,
+                        57.2924835
+                    ],
+                    [
+                        9.4978864,
+                        57.2919578
+                    ],
+                    [
+                        9.4988593,
+                        57.3820608
+                    ],
+                    [
+                        9.6649749,
+                        57.3811615
+                    ],
+                    [
+                        9.6687295,
+                        57.5605591
+                    ],
+                    [
+                        9.8351961,
+                        57.5596265
+                    ],
+                    [
+                        9.8374896,
+                        57.6493322
+                    ],
+                    [
+                        10.1725726,
+                        57.6462818
+                    ],
+                    [
+                        10.1754245,
+                        57.7367768
+                    ],
+                    [
+                        10.5118282,
+                        57.7330269
+                    ],
+                    [
+                        10.5152095,
+                        57.8228945
+                    ],
+                    [
+                        10.6834853,
+                        57.8207722
+                    ],
+                    [
+                        10.6751613,
+                        57.6412021
+                    ],
+                    [
+                        10.5077045,
+                        57.6433097
+                    ],
+                    [
+                        10.5039992,
+                        57.5535088
+                    ],
+                    [
+                        10.671038,
+                        57.5514113
+                    ],
+                    [
+                        10.6507805,
+                        57.1024538
+                    ],
+                    [
+                        10.4857673,
+                        57.1045138
+                    ],
+                    [
+                        10.4786236,
+                        56.9249051
+                    ],
+                    [
+                        10.3143981,
+                        56.9267573
+                    ],
+                    [
+                        10.3112341,
+                        56.8369269
+                    ],
+                    [
+                        10.4750295,
+                        56.83509
+                    ],
+                    [
+                        10.4649016,
+                        56.5656681
+                    ],
+                    [
+                        10.9524239,
+                        56.5589761
+                    ],
+                    [
+                        10.9479249,
+                        56.4692243
+                    ],
+                    [
+                        11.1099335,
+                        56.4664675
+                    ],
+                    [
+                        11.1052639,
+                        56.376833
+                    ],
+                    [
+                        10.9429901,
+                        56.3795284
+                    ],
+                    [
+                        10.9341235,
+                        56.1994768
+                    ],
+                    [
+                        10.7719685,
+                        56.2020244
+                    ],
+                    [
+                        10.7694751,
+                        56.1120103
+                    ],
+                    [
+                        10.6079695,
+                        56.1150259
+                    ],
+                    [
+                        10.4466742,
+                        56.116717
+                    ],
+                    [
+                        10.2865948,
+                        56.118675
+                    ],
+                    [
+                        10.2831527,
+                        56.0281851
+                    ],
+                    [
+                        10.4439274,
+                        56.0270388
+                    ],
+                    [
+                        10.4417713,
+                        55.7579243
+                    ],
+                    [
+                        10.4334961,
+                        55.6693533
+                    ],
+                    [
+                        10.743814,
+                        55.6646861
+                    ],
+                    [
+                        10.743814,
+                        55.5712253
+                    ],
+                    [
+                        10.8969041,
+                        55.5712253
+                    ],
+                    [
+                        10.9051793,
+                        55.3953852
+                    ],
+                    [
+                        11.0613726,
+                        55.3812841
+                    ],
+                    [
+                        11.0593038,
+                        55.1124061
+                    ],
+                    [
+                        11.0458567,
+                        55.0318621
+                    ],
+                    [
+                        11.2030844,
+                        55.0247474
+                    ],
+                    [
+                        11.2030844,
+                        55.117139
+                    ],
+                    [
+                        11.0593038,
+                        55.1124061
+                    ],
+                    [
+                        11.0613726,
+                        55.3812841
+                    ],
+                    [
+                        11.0789572,
+                        55.5712253
+                    ],
+                    [
+                        10.8969041,
+                        55.5712253
+                    ],
+                    [
+                        10.9258671,
+                        55.6670198
+                    ],
+                    [
+                        10.743814,
+                        55.6646861
+                    ],
+                    [
+                        10.7562267,
+                        55.7579243
+                    ],
+                    [
+                        10.4417713,
+                        55.7579243
+                    ],
+                    [
+                        10.4439274,
+                        56.0270388
+                    ],
+                    [
+                        10.4466742,
+                        56.116717
+                    ],
+                    [
+                        10.6079695,
+                        56.1150259
+                    ],
+                    [
+                        10.6052053,
+                        56.0247462
+                    ],
+                    [
+                        10.9258671,
+                        56.0201215
+                    ],
+                    [
+                        10.9197132,
+                        55.9309388
+                    ],
+                    [
+                        11.0802782,
+                        55.92792
+                    ],
+                    [
+                        11.0858066,
+                        56.0178284
+                    ],
+                    [
+                        11.7265047,
+                        56.005058
+                    ],
+                    [
+                        11.7319981,
+                        56.0952142
+                    ],
+                    [
+                        12.0540333,
+                        56.0871256
+                    ],
+                    [
+                        12.0608477,
+                        56.1762576
+                    ],
+                    [
+                        12.7023469,
+                        56.1594405
+                    ],
+                    [
+                        12.6611131,
+                        55.7114318
+                    ],
+                    [
+                        12.9792318,
+                        55.7014026
+                    ],
+                    [
+                        12.9612912,
+                        55.5217294
+                    ],
+                    [
+                        12.3268659,
+                        55.5412096
+                    ],
+                    [
+                        12.3206071,
+                        55.4513655
+                    ],
+                    [
+                        12.4778226,
+                        55.447067
+                    ],
+                    [
+                        12.4702432,
+                        55.3570479
+                    ],
+                    [
+                        12.6269738,
+                        55.3523837
+                    ],
+                    [
+                        12.6200898,
+                        55.2632576
+                    ],
+                    [
+                        12.4627339,
+                        55.26722
+                    ],
+                    [
+                        12.4552949,
+                        55.1778223
+                    ],
+                    [
+                        12.2987046,
+                        55.1822303
+                    ],
+                    [
+                        12.2897344,
+                        55.0923641
+                    ],
+                    [
+                        12.6048608,
+                        55.0832904
+                    ],
+                    [
+                        12.5872011,
+                        54.9036285
+                    ],
+                    [
+                        12.2766618,
+                        54.9119031
+                    ],
+                    [
+                        12.2610181,
+                        54.7331602
+                    ],
+                    [
+                        12.1070691,
+                        54.7378161
+                    ],
+                    [
+                        12.0858621,
+                        54.4681655
+                    ],
+                    [
+                        11.7794953,
+                        54.4753579
+                    ],
+                    [
+                        11.7837381,
+                        54.5654783
+                    ],
+                    [
+                        11.1658525,
+                        54.5782155
+                    ],
+                    [
+                        11.1706443,
+                        54.6686508
+                    ],
+                    [
+                        10.8617173,
+                        54.6733956
+                    ],
+                    [
+                        10.8651245,
+                        54.7634667
+                    ],
+                    [
+                        10.7713646,
+                        54.7643888
+                    ],
+                    [
+                        10.7707276,
+                        54.7372807
+                    ],
+                    [
+                        10.7551428,
+                        54.7375776
+                    ],
+                    [
+                        10.7544039,
+                        54.7195666
+                    ],
+                    [
+                        10.7389074,
+                        54.7197588
+                    ],
+                    [
+                        10.7384368,
+                        54.7108482
+                    ],
+                    [
+                        10.7074486,
+                        54.7113045
+                    ],
+                    [
+                        10.7041094,
+                        54.6756741
+                    ],
+                    [
+                        10.5510973,
+                        54.6781698
+                    ],
+                    [
+                        10.5547184,
+                        54.7670245
+                    ],
+                    [
+                        10.2423994,
+                        54.7705935
+                    ],
+                    [
+                        10.2459845,
+                        54.8604673
+                    ],
+                    [
+                        10.0902268,
+                        54.8622134
+                    ],
+                    [
+                        10.0873731,
+                        54.7723851
+                    ],
+                    [
+                        9.1555798,
+                        54.7769557
+                    ],
+                    [
+                        9.1562752,
+                        54.8675369
+                    ],
+                    [
+                        8.5321973,
+                        54.8663765
+                    ],
+                    [
+                        8.531432,
+                        54.95516
+                    ],
+                    [
+                        8.3743941,
+                        54.9551655
+                    ]
+                ],
+                [
+                    [
+                        11.4577738,
+                        56.819554
+                    ],
+                    [
+                        11.7849181,
+                        56.8127385
+                    ],
+                    [
+                        11.7716715,
+                        56.6332796
+                    ],
+                    [
+                        11.4459621,
+                        56.6401087
+                    ],
+                    [
+                        11.4577738,
+                        56.819554
+                    ]
+                ],
+                [
+                    [
+                        11.3274736,
+                        57.3612962
+                    ],
+                    [
+                        11.3161808,
+                        57.1818004
+                    ],
+                    [
+                        11.1508692,
+                        57.1847276
+                    ],
+                    [
+                        11.1456628,
+                        57.094962
+                    ],
+                    [
+                        10.8157703,
+                        57.1001693
+                    ],
+                    [
+                        10.8290599,
+                        57.3695272
+                    ],
+                    [
+                        11.3274736,
+                        57.3612962
+                    ]
+                ],
+                [
+                    [
+                        11.5843266,
+                        56.2777928
+                    ],
+                    [
+                        11.5782882,
+                        56.1880397
+                    ],
+                    [
+                        11.7392309,
+                        56.1845765
+                    ],
+                    [
+                        11.7456428,
+                        56.2743186
+                    ],
+                    [
+                        11.5843266,
+                        56.2777928
+                    ]
+                ],
+                [
+                    [
+                        14.6825922,
+                        55.3639405
+                    ],
+                    [
+                        14.8395247,
+                        55.3565231
+                    ],
+                    [
+                        14.8263755,
+                        55.2671261
+                    ],
+                    [
+                        15.1393406,
+                        55.2517359
+                    ],
+                    [
+                        15.1532015,
+                        55.3410836
+                    ],
+                    [
+                        15.309925,
+                        55.3330556
+                    ],
+                    [
+                        15.295719,
+                        55.2437356
+                    ],
+                    [
+                        15.1393406,
+                        55.2517359
+                    ],
+                    [
+                        15.1255631,
+                        55.1623802
+                    ],
+                    [
+                        15.2815819,
+                        55.1544167
+                    ],
+                    [
+                        15.2535578,
+                        54.9757646
+                    ],
+                    [
+                        14.6317464,
+                        55.0062496
+                    ],
+                    [
+                        14.6825922,
+                        55.3639405
+                    ]
+                ]
+            ],
+            "terms_url": "http://download.kortforsyningen.dk/content/vilkaar-og-betingelser",
+            "terms_text": "Geodatastyrelsen og Danske Kommuner",
+            "best": true
+        },
+        {
             "id": "Slovakia-Historic-Maps",
             "name": "Slovakia Historic Maps",
             "type": "tms",
@@ -52040,6 +57149,465 @@
                     ]
                 ]
             ]
+        },
+        {
+            "id": "Soskut_Pusztazamor_Tarnok_Diosd_orto_2017",
+            "name": "Sóskút, Pusztazámor, Tárnok, Diósd ortophoto 2017",
+            "type": "tms",
+            "template": "http://adam.openstreetmap.hu/mapproxy/tiles/1.0.0/Soskut-Tarnok-Pusztazamor-Diosd/mercator/{zoom}/{x}/{y}.png",
+            "polygon": [
+                [
+                    [
+                        18.79273330201,
+                        47.37078533804
+                    ],
+                    [
+                        18.791936169,
+                        47.37048036201
+                    ],
+                    [
+                        18.79139114593,
+                        47.37063268281
+                    ],
+                    [
+                        18.7901097,
+                        47.3717614
+                    ],
+                    [
+                        18.7891647,
+                        47.3734529
+                    ],
+                    [
+                        18.78721506824,
+                        47.37566027041
+                    ],
+                    [
+                        18.7860339,
+                        47.37764910001
+                    ],
+                    [
+                        18.7849824,
+                        47.3790513
+                    ],
+                    [
+                        18.783695,
+                        47.3803226
+                    ],
+                    [
+                        18.782665,
+                        47.3819499
+                    ],
+                    [
+                        18.781399,
+                        47.3836789
+                    ],
+                    [
+                        18.7793426,
+                        47.3871257
+                    ],
+                    [
+                        18.776657,
+                        47.3893959
+                    ],
+                    [
+                        18.764716,
+                        47.396699
+                    ],
+                    [
+                        18.7616966,
+                        47.3996569
+                    ],
+                    [
+                        18.7563102,
+                        47.4032821
+                    ],
+                    [
+                        18.7583737,
+                        47.4065272
+                    ],
+                    [
+                        18.75879657883,
+                        47.40776342073
+                    ],
+                    [
+                        18.76199554897,
+                        47.41217224817
+                    ],
+                    [
+                        18.7630394973,
+                        47.41315137445
+                    ],
+                    [
+                        18.7659298,
+                        47.4147108
+                    ],
+                    [
+                        18.7704058,
+                        47.4176575
+                    ],
+                    [
+                        18.77247285488,
+                        47.41808545272
+                    ],
+                    [
+                        18.7724806,
+                        47.4202978
+                    ],
+                    [
+                        18.8086021,
+                        47.4404108
+                    ],
+                    [
+                        18.8174212,
+                        47.435389
+                    ],
+                    [
+                        18.8209188,
+                        47.4357228
+                    ],
+                    [
+                        18.8280427,
+                        47.4375516
+                    ],
+                    [
+                        18.8302099,
+                        47.4352584
+                    ],
+                    [
+                        18.8358533,
+                        47.4375371
+                    ],
+                    [
+                        18.8404882,
+                        47.4334586
+                    ],
+                    [
+                        18.847655,
+                        47.4357228
+                    ],
+                    [
+                        18.8510024,
+                        47.4328054
+                    ],
+                    [
+                        18.8689996,
+                        47.4396086
+                    ],
+                    [
+                        18.87361350924,
+                        47.43597176329
+                    ],
+                    [
+                        18.87499181607,
+                        47.43342149293
+                    ],
+                    [
+                        18.87386045593,
+                        47.43248349864
+                    ],
+                    [
+                        18.8760377,
+                        47.4279677
+                    ],
+                    [
+                        18.8605023,
+                        47.4230028
+                    ],
+                    [
+                        18.8662101,
+                        47.4179794
+                    ],
+                    [
+                        18.8724328,
+                        47.4108645
+                    ],
+                    [
+                        18.8662959,
+                        47.4077278
+                    ],
+                    [
+                        18.8696433,
+                        47.4047072
+                    ],
+                    [
+                        18.86776892261,
+                        47.40207457802
+                    ],
+                    [
+                        18.86509430105,
+                        47.40052438512
+                    ],
+                    [
+                        18.87081279074,
+                        47.3983820654
+                    ],
+                    [
+                        18.86772375423,
+                        47.39699336542
+                    ],
+                    [
+                        18.86992005424,
+                        47.39655168559
+                    ],
+                    [
+                        18.87648610191,
+                        47.39477958954
+                    ],
+                    [
+                        18.87748924808,
+                        47.39494663392
+                    ],
+                    [
+                        18.87866942005,
+                        47.39462343887
+                    ],
+                    [
+                        18.88358322696,
+                        47.3899604942
+                    ],
+                    [
+                        18.88290731029,
+                        47.3896699544
+                    ],
+                    [
+                        18.88538567142,
+                        47.38530440107
+                    ],
+                    [
+                        18.87747851924,
+                        47.38339390377
+                    ],
+                    [
+                        18.88181296901,
+                        47.37604910406
+                    ],
+                    [
+                        18.87914148883,
+                        47.37392756692
+                    ],
+                    [
+                        18.88638345317,
+                        47.36922645965
+                    ],
+                    [
+                        18.88205973224,
+                        47.36772957402
+                    ],
+                    [
+                        18.87973157482,
+                        47.36640704749
+                    ],
+                    [
+                        18.8746997507,
+                        47.36252284243
+                    ],
+                    [
+                        18.87282220439,
+                        47.36136733615
+                    ],
+                    [
+                        18.87027947025,
+                        47.36062605465
+                    ],
+                    [
+                        18.86687842922,
+                        47.3585329683
+                    ],
+                    [
+                        18.86234013156,
+                        47.35637438604
+                    ],
+                    [
+                        18.85566679554,
+                        47.35199153827
+                    ],
+                    [
+                        18.84873596744,
+                        47.34728120653
+                    ],
+                    [
+                        18.83192388134,
+                        47.3384118486
+                    ],
+                    [
+                        18.82497159557,
+                        47.34257772442
+                    ],
+                    [
+                        18.81619540767,
+                        47.34925116493
+                    ],
+                    [
+                        18.8107880743,
+                        47.35356882392
+                    ],
+                    [
+                        18.80823461132,
+                        47.35599644336
+                    ],
+                    [
+                        18.80645362453,
+                        47.35854023611
+                    ],
+                    [
+                        18.80707589702,
+                        47.359019909
+                    ],
+                    [
+                        18.80634633617,
+                        47.36021180457
+                    ],
+                    [
+                        18.80465118007,
+                        47.36175250772
+                    ],
+                    [
+                        18.80381433086,
+                        47.36335130305
+                    ],
+                    [
+                        18.80054616504,
+                        47.36544732015
+                    ],
+                    [
+                        18.79988097721,
+                        47.36617355102
+                    ],
+                    [
+                        18.79416204336,
+                        47.36974865444
+                    ],
+                    [
+                        18.79273330201,
+                        47.37078533804
+                    ]
+                ],
+                [
+                    [
+                        18.91871480064,
+                        47.4093812629
+                    ],
+                    [
+                        18.91826418952,
+                        47.40997664498
+                    ],
+                    [
+                        18.9206674488,
+                        47.41155945729
+                    ],
+                    [
+                        18.92509845809,
+                        47.41372304121
+                    ],
+                    [
+                        18.93473295288,
+                        47.41916790937
+                    ],
+                    [
+                        18.94063381271,
+                        47.42241278301
+                    ],
+                    [
+                        18.94981769638,
+                        47.41937843296
+                    ],
+                    [
+                        18.95154503898,
+                        47.41749820965
+                    ],
+                    [
+                        18.95689872818,
+                        47.41922598493
+                    ],
+                    [
+                        18.95770339088,
+                        47.41877589767
+                    ],
+                    [
+                        18.95755318717,
+                        47.41435467478
+                    ],
+                    [
+                        18.9621129425,
+                        47.40506817222
+                    ],
+                    [
+                        18.96266011314,
+                        47.40117592194
+                    ],
+                    [
+                        18.96316436843,
+                        47.39903360927
+                    ],
+                    [
+                        18.95446328239,
+                        47.3967314338
+                    ],
+                    [
+                        18.95275739746,
+                        47.39526437993
+                    ],
+                    [
+                        18.95201710777,
+                        47.39362297422
+                    ],
+                    [
+                        18.95119098739,
+                        47.39356487042
+                    ],
+                    [
+                        18.94692091064,
+                        47.39798783856
+                    ],
+                    [
+                        18.94410995559,
+                        47.3984526281
+                    ],
+                    [
+                        18.94161013679,
+                        47.39868502134
+                    ],
+                    [
+                        18.93735078887,
+                        47.39633199249
+                    ],
+                    [
+                        18.93617061691,
+                        47.39682584676
+                    ],
+                    [
+                        18.93122462348,
+                        47.39999947627
+                    ],
+                    [
+                        18.93120316581,
+                        47.40023186269
+                    ],
+                    [
+                        18.92923978881,
+                        47.40204734624
+                    ],
+                    [
+                        18.92561344223,
+                        47.40604845111
+                    ],
+                    [
+                        18.92465857582,
+                        47.40635342305
+                    ],
+                    [
+                        18.92293123321,
+                        47.40925782918
+                    ],
+                    [
+                        18.91871480064,
+                        47.4093812629
+                    ]
+                ]
+            ],
+            "terms_url": "http://fototerkep.hu/",
+            "terms_text": "Fototerkep.hu",
+            "best": true
         },
         {
             "id": "South_Africa-CD_NGI-Aerial",
@@ -53245,7 +58813,6 @@
             "name": "South Tyrol Orthofoto 2011",
             "type": "tms",
             "template": "http://geoservices.buergernetz.bz.it/geoserver/gwc/service/wmts/?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=P_BZ_OF_2011_EPSG3857&STYLE=default&TILEMATRIXSET=GoogleMapsCompatible&TILEMATRIX=GoogleMapsCompatible%3A{zoom}&TILEROW={y}&TILECOL={x}&FORMAT=image%2Fjpeg",
-            "description": "Orthophoto of South Tyrol from 2011",
             "scaleExtent": [
                 0,
                 18
@@ -55138,7 +60705,6 @@
             "name": "South Tyrol Orthofoto 2014",
             "type": "tms",
             "template": "http://geoservices.buergernetz.bz.it/geoserver/gwc/service/wmts/?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=P_BZ_OF_2014_EPSG3857&STYLE=default&TILEMATRIXSET=GoogleMapsCompatible&TILEMATRIX=GoogleMapsCompatible%3A{zoom}&TILEROW={y}&TILECOL={x}&FORMAT=image%2Fjpeg",
-            "description": "Orthophoto of South Tyrol from 2011",
             "scaleExtent": [
                 0,
                 18
@@ -58653,7 +64219,7 @@
         },
         {
             "id": "Stevns_Denmark",
-            "name": "Stevns (Denmark)",
+            "name": "Stevns",
             "type": "tms",
             "template": "http://{switch:a,b,c}.tile.openstreetmap.dk/stevns/2009/{zoom}/{x}/{y}.png",
             "scaleExtent": [
@@ -59282,7 +64848,7 @@
         },
         {
             "id": "Szeged_2011",
-            "name": "Szeged ortophoto 2011",
+            "name": "Szeged orthophoto 2011",
             "type": "tms",
             "template": "http://e.tile.openstreetmap.hu/szeged-2011-10cm/{zoom}/{x}/{y}.png",
             "scaleExtent": [
@@ -59506,7 +65072,8 @@
                 ]
             ],
             "terms_url": "http://www.geo.u-szeged.hu/",
-            "terms_text": "SZTE TFGT - University of Szeged"
+            "terms_text": "SZTE TFGT - University of Szeged",
+            "best": true
         },
         {
             "id": "tnris.org",
@@ -62247,7 +67814,7 @@
             "id": "US_Forest_Service_roads",
             "name": "U.S. Forest Service roads",
             "type": "tms",
-            "template": "http://osm.cycle.travel/forest/{zoom}/{x}/{y}.png",
+            "template": "https://osm.cycle.travel/forest/{zoom}/{x}/{y}.png",
             "scaleExtent": [
                 0,
                 19
@@ -66954,803 +72521,519 @@
             "id": "USGS-Scanned_Topographic",
             "name": "USGS Topographic Maps",
             "type": "tms",
-            "template": "http://{switch:a,b,c}.tile.openstreetmap.us/usgs_scanned_topos/{zoom}/{x}/{y}.png",
+            "template": "https://caltopo.s3.amazonaws.com/topo/{zoom}/{x}/{y}.png",
+            "scaleExtent": [
+                0,
+                16
+            ],
             "polygon": [
                 [
                     [
-                        -125.990173,
-                        48.9962416
+                        -55.9959409871,
+                        52.00107125754
                     ],
                     [
-                        -125.989419,
-                        47.9948396
+                        -112.02896100663,
+                        52.00107125754
                     ],
                     [
-                        -123.9929739,
-                        47.9955062
+                        -112.03994733476,
+                        56.01308253302
                     ],
                     [
-                        -123.9922429,
-                        47.0059202
+                        -120.0049439862,
+                        56.00592357111
                     ],
                     [
-                        -125.988688,
-                        47.0052409
+                        -120.01711631014,
+                        60.01202439709
                     ],
                     [
-                        -125.9879604,
-                        46.0015618
+                        -132.00196823895,
+                        60.00239237126
                     ],
                     [
-                        -123.9939396,
-                        46.0022529
+                        -132.01208445818,
+                        63.00193292546
                     ],
                     [
-                        -123.9925238,
-                        43.9961708
+                        -133.96882922149,
+                        63.00050478005
                     ],
                     [
-                        -124.9931832,
-                        43.9958116
+                        -133.97240257168,
+                        63.9922484722
                     ],
                     [
-                        -124.9918175,
-                        41.9942149
+                        -141.04429430438,
+                        63.98726254018
                     ],
                     [
-                        -125.9851789,
-                        41.9938465
+                        -141.06879354491,
+                        69.92045693283
                     ],
                     [
-                        -125.9838655,
-                        40.0076111
+                        -156.24893170976,
+                        71.51583202984
                     ],
                     [
-                        -123.9833285,
-                        40.0083757
+                        -160.44570905351,
+                        70.83527373985
                     ],
                     [
-                        -123.9814115,
-                        37.002615
+                        -167.08145124101,
+                        68.42906280103
                     ],
                     [
-                        -122.21903,
-                        37.0033173
+                        -164.08218366288,
+                        67.03913532024
                     ],
                     [
-                        -122.2184144,
-                        36.011671
+                        -169.01504499101,
+                        65.68268604273
                     ],
                     [
-                        -122.020087,
-                        36.011751
+                        -166.57608014726,
+                        64.50777504773
                     ],
                     [
-                        -122.0188591,
-                        33.9961766
+                        -161.82998639726,
+                        64.0500622981
                     ],
                     [
-                        -119.9787757,
-                        33.9970206
+                        -165.08193952226,
+                        63.26030016403
                     ],
                     [
-                        -119.9775867,
-                        31.9987658
+                        -168.02627545976,
+                        59.7862264253
                     ],
                     [
-                        -114.0122833,
-                        32.00129
+                        -162.53311139726,
+                        59.73089435789
                     ],
                     [
-                        -114.0116894,
-                        30.9862401
+                        -162.35733014726,
+                        58.55904663221
                     ],
                     [
-                        -105.998294,
-                        30.9896679
+                        -157.83096295976,
+                        58.31752983705
                     ],
                     [
-                        -105.9971419,
-                        28.9901065
+                        -158.00674420976,
+                        57.52404350658
                     ],
                     [
-                        -102.0210506,
-                        28.9918418
+                        -168.22402936601,
+                        53.51022153947
                     ],
                     [
-                        -102.0204916,
-                        28.00733
+                        -166.55410749101,
+                        53.14277307072
                     ],
                     [
-                        -100.0062436,
-                        28.0082173
+                        -158.77578717851,
+                        54.88541314654
                     ],
                     [
-                        -100.0051143,
-                        25.991909
+                        -158.68240338944,
+                        55.7496444805
                     ],
                     [
-                        -98.0109067,
-                        25.9928035
+                        -156.55105573319,
+                        56.00847621073
                     ],
                     [
-                        -98.0103613,
-                        25.0063461
+                        -156.15554792069,
+                        56.7746616888
                     ],
                     [
-                        -97.0161086,
-                        25.0067957
+                        -154.70535260819,
+                        56.14336689443
                     ],
                     [
-                        -97.016654,
-                        25.9932494
+                        -152.07412702226,
+                        57.37034511851
                     ],
                     [
-                        -95.9824825,
-                        25.9937132
+                        -151.62918073319,
+                        58.22653323066
                     ],
                     [
-                        -95.9835999,
-                        27.9891175
+                        -152.00820905351,
+                        58.98055685754
                     ],
                     [
-                        -94.0200898,
-                        27.9899826
+                        -145.98770124101,
+                        60.24740887373
                     ],
                     [
-                        -94.0206586,
-                        28.9918129
+                        -140.38467389726,
+                        59.48634241018
                     ],
                     [
-                        -88.0156706,
-                        28.9944338
+                        -136.53945905351,
+                        57.80610084736
                     ],
                     [
-                        -88.0162494,
-                        30.0038862
+                        -133.79287702226,
+                        54.83482554482
                     ],
                     [
-                        -86.0277506,
-                        30.0047454
+                        -133.33145124101,
+                        53.14277307072
                     ],
                     [
-                        -86.0271719,
-                        28.9953016
+                        -131.46377545976,
+                        51.69838238021
                     ],
                     [
-                        -84.0187909,
-                        28.9961781
+                        -128.52493268632,
+                        51.74602265442
                     ],
                     [
-                        -84.017095,
-                        25.9817708
+                        -129.79385358476,
+                        50.90159054062
                     ],
                     [
-                        -81.9971976,
-                        25.9826768
+                        -124.56436139726,
+                        47.49785657441
                     ],
                     [
-                        -81.9966618,
-                        25.0134917
+                        -124.03701764726,
+                        45.48627362525
                     ],
                     [
-                        -84.0165592,
-                        25.0125783
+                        -124.69619733476,
+                        42.90428451679
                     ],
                     [
-                        -84.0160068,
-                        24.0052745
+                        -124.49844342851,
+                        40.3414647251
                     ],
                     [
-                        -80.0199985,
-                        24.007096
+                        -122.80654889726,
+                        37.53929308709
                     ],
                     [
-                        -80.0245309,
-                        32.0161282
+                        -119.99404889726,
+                        33.37084692374
                     ],
                     [
-                        -78.0066484,
-                        32.0169819
+                        -117.24746686601,
+                        32.54119524801
                     ],
                     [
-                        -78.0072238,
-                        32.9894278
+                        -111.13906842851,
+                        31.19770451575
                     ],
                     [
-                        -77.8807233,
-                        32.9894807
+                        -106.70059186601,
+                        31.23528720858
                     ],
                     [
-                        -77.8813253,
-                        33.9955918
+                        -103.20693952226,
+                        28.64618215851
                     ],
                     [
-                        -76.0115411,
-                        33.9963653
+                        -101.84463483476,
+                        29.81580068657
                     ],
                     [
-                        -76.0121459,
-                        34.9952552
+                        -99.20791608476,
+                        26.28743998885
                     ],
                     [
-                        -74.0068449,
-                        34.9960749
+                        -96.79092389726,
+                        25.75431753335
                     ],
                     [
-                        -74.0099997,
-                        40.0084254
+                        -96.92275983476,
+                        27.96911213371
                     ],
                     [
-                        -72.0013745,
-                        40.0091931
+                        -93.47305280351,
+                        29.68226300815
                     ],
                     [
-                        -72.002019,
-                        40.9912464
+                        -88.94668561601,
+                        28.87732407469
                     ],
                     [
-                        -69.8797398,
-                        40.9920457
+                        -88.61709577226,
+                        30.17736083469
                     ],
                     [
-                        -69.8804173,
-                        42.00893
+                        -86.20010358476,
+                        30.3671253082
                     ],
                     [
-                        -69.9927682,
-                        42.0088883
+                        -84.96963483476,
+                        29.43379356715
                     ],
                     [
-                        -69.9934462,
-                        43.0105166
+                        -84.09072858476,
+                        30.06332630046
                     ],
                     [
-                        -67.9845366,
-                        43.0112496
+                        -82.97012311601,
+                        28.95425748047
                     ],
                     [
-                        -67.985224,
-                        44.0103812
+                        -82.97012311601,
+                        27.26823750278
                     ],
                     [
-                        -65.9892568,
-                        44.0110975
+                        -81.25625592851,
+                        25.07956298739
                     ],
                     [
-                        -65.9921237,
-                        47.9993584
+                        -82.09121686601,
+                        24.5610471236
                     ],
                     [
-                        -70.006442,
-                        47.9980181
+                        -80.06973249101,
+                        24.76073298597
                     ],
                     [
-                        -70.005708,
-                        47.0042007
+                        -79.85000592851,
+                        27.11188091684
                     ],
                     [
-                        -72.023686,
-                        47.003514
+                        -81.27822858476,
+                        30.70777424386
                     ],
                     [
-                        -72.0222508,
-                        45.0059846
+                        -78.99307233476,
+                        33.20554049136
                     ],
                     [
-                        -78.0146667,
-                        45.0038705
+                        -75.03799420976,
+                        35.59830000028
                     ],
                     [
-                        -78.0139662,
-                        44.0026998
+                        -75.85098249101,
+                        37.2425160052
                     ],
                     [
-                        -80.029686,
-                        44.0019763
+                        -73.74160749101,
+                        40.4585957587
                     ],
                     [
-                        -80.0290052,
-                        43.0122994
+                        -69.89639264726,
+                        41.60224497127
                     ],
                     [
-                        -81.995479,
-                        43.011582
+                        -70.68740827226,
+                        43.17628724449
                     ],
                     [
-                        -81.9982986,
-                        47.0042713
+                        -66.93008405351,
+                        44.69516042167
                     ],
                     [
-                        -87.505706,
-                        47.0023972
+                        -66.53457624101,
+                        43.08006996122
                     ],
                     [
-                        -87.5064535,
-                        48.0142702
+                        -64.20547467851,
+                        43.35229243812
                     ],
                     [
-                        -88.0260889,
-                        48.0140968
+                        -59.50332624101,
+                        45.73220792131
                     ],
                     [
-                        -88.026838,
-                        49.0086686
+                        -59.51431256913,
+                        46.24761804024
                     ],
                     [
-                        -93.9981078,
-                        49.0067142
+                        -60.00320417069,
+                        46.25901313529
                     ],
                     [
-                        -93.9988778,
-                        50.0086456
+                        -59.99221784257,
+                        47.24505773341
                     ],
                     [
-                        -96.0138899,
-                        50.0079995
+                        -59.00894147538,
+                        47.23759898478
                     ],
                     [
-                        -96.0131199,
-                        49.0060547
+                        -58.99795514726,
+                        47.50266941922
                     ],
                     [
-                        -125.990173,
-                        48.9962416
+                        -56.51504499101,
+                        47.50266941922
+                    ],
+                    [
+                        -56.52603131913,
+                        46.74770404019
+                    ],
+                    [
+                        -53.99917585038,
+                        46.74770404019
+                    ],
+                    [
+                        -53.97720319413,
+                        46.48358117386
+                    ],
+                    [
+                        -52.49404889726,
+                        46.46354265729
+                    ],
+                    [
+                        -52.50503522538,
+                        48.75360583388
+                    ],
+                    [
+                        -52.99667340898,
+                        48.75451123442
+                    ],
+                    [
+                        -53.01315290116,
+                        49.99551104004
+                    ],
+                    [
+                        -55.00167829179,
+                        50.00610367548
+                    ],
+                    [
+                        -55.03738385819,
+                        53.74720613495
+                    ],
+                    [
+                        -56.00418073319,
+                        53.73421061801
+                    ],
+                    [
+                        -55.9959409871,
+                        52.00107125754
                     ]
                 ],
                 [
                     [
-                        -160.5787616,
-                        22.5062947
+                        -59.50126630448,
+                        43.7495431608
                     ],
                     [
-                        -160.5782192,
-                        21.4984647
+                        -60.50239545487,
+                        43.7495431608
                     ],
                     [
-                        -159.0030121,
-                        21.499196
+                        -60.50239545487,
+                        43.99999882251
                     ],
                     [
-                        -159.0027422,
-                        20.9951068
+                        -59.99839765214,
+                        43.99999882251
                     ],
                     [
-                        -157.5083185,
-                        20.995803
+                        -59.99839765214,
+                        44.2494016836
                     ],
                     [
-                        -157.5080519,
-                        20.4960241
+                        -59.50126630448,
+                        44.2494016836
                     ],
                     [
-                        -155.966889,
-                        20.4967444
-                    ],
-                    [
-                        -155.9674267,
-                        21.5028287
-                    ],
-                    [
-                        -157.5044717,
-                        21.5021151
-                    ],
-                    [
-                        -157.5047384,
-                        21.9984962
-                    ],
-                    [
-                        -159.0090946,
-                        21.9978002
-                    ],
-                    [
-                        -159.0093692,
-                        22.5070181
-                    ],
-                    [
-                        -160.5787616,
-                        22.5062947
+                        -59.50126630448,
+                        43.7495431608
                     ]
                 ],
                 [
                     [
-                        -168.006102,
-                        68.9941463
+                        -155.95024091386,
+                        20.49523373356
                     ],
                     [
-                        -168.0047628,
-                        68.0107853
+                        -157.3267518687,
+                        20.49153389084
                     ],
                     [
-                        -165.4842481,
-                        68.0112562
+                        -157.32902509355,
+                        21.23181053727
                     ],
                     [
-                        -165.4829337,
-                        67.0037303
+                        -155.95251413871,
+                        21.23549220541
                     ],
                     [
-                        -168.0034485,
-                        67.0032389
-                    ],
-                    [
-                        -168.002195,
-                        66.0017503
-                    ],
-                    [
-                        -169.0087448,
-                        66.001546
-                    ],
-                    [
-                        -169.0075381,
-                        64.9987675
-                    ],
-                    [
-                        -168.0009882,
-                        64.9989798
-                    ],
-                    [
-                        -167.9998282,
-                        63.9982374
-                    ],
-                    [
-                        -164.9871288,
-                        63.9988964
-                    ],
-                    [
-                        -164.9860062,
-                        62.9950845
-                    ],
-                    [
-                        -167.9987057,
-                        62.9944019
-                    ],
-                    [
-                        -167.9946035,
-                        59.0153692
-                    ],
-                    [
-                        -162.5027857,
-                        59.0167799
-                    ],
-                    [
-                        -162.5018149,
-                        58.0005815
-                    ],
-                    [
-                        -160.0159024,
-                        58.0012389
-                    ],
-                    [
-                        -160.0149725,
-                        57.000035
-                    ],
-                    [
-                        -160.5054788,
-                        56.9999017
-                    ],
-                    [
-                        -160.5045719,
-                        55.9968161
-                    ],
-                    [
-                        -164.012195,
-                        55.9958373
-                    ],
-                    [
-                        -164.0113186,
-                        55.00107
-                    ],
-                    [
-                        -165.994782,
-                        55.0005023
-                    ],
-                    [
-                        -165.9941266,
-                        54.2400584
-                    ],
-                    [
-                        -168.0002944,
-                        54.2394734
-                    ],
-                    [
-                        -168.0000986,
-                        54.0094921
-                    ],
-                    [
-                        -170.0156134,
-                        54.0089011
-                    ],
-                    [
-                        -170.0147683,
-                        53.0016446
-                    ],
-                    [
-                        -171.9993636,
-                        53.0010487
-                    ],
-                    [
-                        -171.9989488,
-                        52.4977745
-                    ],
-                    [
-                        -176.0083239,
-                        52.4965566
-                    ],
-                    [
-                        -176.0081186,
-                        52.2452555
-                    ],
-                    [
-                        -178.000097,
-                        52.2446469
-                    ],
-                    [
-                        -177.9992996,
-                        51.2554252
-                    ],
-                    [
-                        -176.0073212,
-                        51.2560472
-                    ],
-                    [
-                        -176.0075146,
-                        51.4980163
-                    ],
-                    [
-                        -171.9981395,
-                        51.4992617
-                    ],
-                    [
-                        -171.9985419,
-                        51.9985373
-                    ],
-                    [
-                        -167.9984317,
-                        51.9997661
-                    ],
-                    [
-                        -167.9994645,
-                        53.2560877
-                    ],
-                    [
-                        -165.9932968,
-                        53.2566866
-                    ],
-                    [
-                        -165.9939308,
-                        54.0100804
-                    ],
-                    [
-                        -159.0067205,
-                        54.0121291
-                    ],
-                    [
-                        -159.0075717,
-                        55.002502
-                    ],
-                    [
-                        -158.0190709,
-                        55.0027849
-                    ],
-                    [
-                        -158.0199473,
-                        55.9975094
-                    ],
-                    [
-                        -151.9963213,
-                        55.9991902
-                    ],
-                    [
-                        -151.9981536,
-                        57.9986536
-                    ],
-                    [
-                        -151.500341,
-                        57.9987853
-                    ],
-                    [
-                        -151.5012894,
-                        58.9919816
-                    ],
-                    [
-                        -138.5159989,
-                        58.9953194
-                    ],
-                    [
-                        -138.5150471,
-                        57.9986434
-                    ],
-                    [
-                        -136.6872422,
-                        57.9991267
-                    ],
-                    [
-                        -136.6863158,
-                        57.0016688
-                    ],
-                    [
-                        -135.9973698,
-                        57.001856
-                    ],
-                    [
-                        -135.9964667,
-                        56.0030544
-                    ],
-                    [
-                        -134.6717732,
-                        56.003424
-                    ],
-                    [
-                        -134.6708865,
-                        54.9969623
-                    ],
-                    [
-                        -133.9956734,
-                        54.9971556
-                    ],
-                    [
-                        -133.9948193,
-                        54.0031685
-                    ],
-                    [
-                        -130.0044418,
-                        54.0043387
-                    ],
-                    [
-                        -130.0070826,
-                        57.0000507
-                    ],
-                    [
-                        -131.975877,
-                        56.9995156
-                    ],
-                    [
-                        -131.9787378,
-                        59.9933094
-                    ],
-                    [
-                        -138.0071813,
-                        59.991805
-                    ],
-                    [
-                        -138.0082158,
-                        61.0125755
-                    ],
-                    [
-                        -140.9874011,
-                        61.0118551
-                    ],
-                    [
-                        -140.99984,
-                        71.0039309
-                    ],
-                    [
-                        -154.5023956,
-                        71.0017377
-                    ],
-                    [
-                        -154.5039632,
-                        71.9983391
-                    ],
-                    [
-                        -157.499048,
-                        71.9978773
-                    ],
-                    [
-                        -157.4974758,
-                        70.9982877
-                    ],
-                    [
-                        -163.0233611,
-                        70.9973899
-                    ],
-                    [
-                        -163.0218273,
-                        69.9707435
-                    ],
-                    [
-                        -164.9730896,
-                        69.97041
-                    ],
-                    [
-                        -164.9717003,
-                        68.994689
-                    ],
-                    [
-                        -168.006102,
-                        68.9941463
+                        -155.95024091386,
+                        20.49523373356
                     ]
                 ],
                 [
                     [
-                        -168.5133204,
-                        62.8689586
+                        -157.64488202714,
+                        21.24845058596
                     ],
                     [
-                        -168.5144423,
-                        63.8765677
+                        -158.28534362719,
+                        21.24673774522
                     ],
                     [
-                        -172.0202755,
-                        63.8757975
+                        -158.28689557694,
+                        21.7499618541
                     ],
                     [
-                        -172.0191536,
-                        62.8681608
+                        -157.6464339769,
+                        21.75166877943
                     ],
                     [
-                        -168.5133204,
-                        62.8689586
+                        -157.64488202714,
+                        21.24845058596
                     ]
                 ],
                 [
                     [
-                        -170.9947111,
-                        59.9954089
+                        -156.12602216386,
+                        20.32469602374
                     ],
                     [
-                        -170.995726,
-                        60.9969787
+                        -154.7461696274,
+                        20.3284088686
                     ],
                     [
-                        -174.0045311,
-                        60.9962508
+                        -154.74174482011,
+                        18.87578125335
                     ],
                     [
-                        -174.0035162,
-                        59.9946581
+                        -156.12159735656,
+                        18.87203473488
                     ],
                     [
-                        -170.9947111,
-                        59.9954089
+                        -156.12602216386,
+                        20.32469602374
                     ]
                 ],
                 [
                     [
-                        -156.0717261,
-                        20.2854602
+                        -159.29077130937,
+                        22.24504086823
                     ],
                     [
-                        -154.7940471,
-                        20.2860582
+                        -159.2892966564,
+                        21.76857042389
                     ],
                     [
-                        -154.7933145,
-                        18.9029464
+                        -160.28916841131,
+                        21.76590592196
                     ],
                     [
-                        -156.0709936,
-                        18.9023432
+                        -160.29064306428,
+                        22.24238530626
                     ],
                     [
-                        -156.0717261,
-                        20.2854602
-                    ]
-                ],
-                [
-                    [
-                        -170.9996252,
-                        57.4005339
-                    ],
-                    [
-                        -169.0007481,
-                        57.3999462
-                    ],
-                    [
-                        -168.9994704,
-                        56.3988562
-                    ],
-                    [
-                        -171.0011935,
-                        56.3991836
-                    ],
-                    [
-                        -170.9996252,
-                        57.4005339
+                        -159.29077130937,
+                        22.24504086823
                     ]
                 ]
-            ]
+            ],
+            "terms_url": "https://caltopo.com/",
+            "terms_text": "© Caltopo"
         },
         {
             "id": "sjcgis.org-General_Basemap_WM",
@@ -67814,7 +73097,7 @@
         },
         {
             "id": "Vejmidte_Denmark",
-            "name": "Vejmidte (Denmark)",
+            "name": "Vejmidte",
             "type": "tms",
             "template": "http://{switch:a,b,c}.tile.openstreetmap.dk/danmark/vejmidte/{zoom}/{x}/{y}.png",
             "scaleExtent": [

--- a/data/update_imagery.js
+++ b/data/update_imagery.js
@@ -34,6 +34,19 @@ var blacklist = {
 
 var whitelist = [
     // Add custom sources here if needed.
+    // Pre/Post event imagary - https://github.com/hotosm/iD/issues/1
+    {
+        "id": "2010-eq-pre-event",
+        "name": "2010 EQ pre-event imagery",
+        "type": "tms",
+        "url": "http://tiles.staging.openaerialmap.org/58efcec02d30b500119a84f4/0/{z}/{x}/{y}.png"
+    },
+    {
+        "id": "2010-eq-post-event",
+        "name": "2010 EQ post-event imagery",
+        "type": "tms",
+        "url": "http://tiles.staging.openaerialmap.org/58ef73b596b4910010327d45/0/{z}/{x}/{y}.png"
+    }
 ];
 
 var descriptions = {
@@ -42,7 +55,7 @@ var descriptions = {
     'MAPNIK': 'The default OpenStreetMap layer.'
 };
 
-sources.concat(whitelist).forEach(function(source) {
+whitelist.concat(sources).forEach(function(source) {
     if (source.type !== 'tms' && source.type !== 'bing') return;
     if (source.id in blacklist) return;
 


### PR DESCRIPTION
(closes #1)

Please check the tile urls in `update_imagery.js` - I'm seeing 404 Not Found when trying to use these sources.

cc @cgiovando  